### PR TITLE
Back button and selection handling in pod Details

### DIFF
--- a/src/WebUI/Common/BaseKubeTable.tsx
+++ b/src/WebUI/Common/BaseKubeTable.tsx
@@ -28,7 +28,7 @@ export interface ITableComponentProperties<T> extends IVssComponentProperties {
     headingText?: string | JSX.Element;
     headingDescription?: string;
     hideHeaders?: boolean;
-    hideLines?:boolean;
+    hideLines?: boolean;
     items: T[];
     columns: ITableColumn<T>[];
     onItemActivated?: (event: React.SyntheticEvent<HTMLElement>, tableRow: ITableRow<any>, selectedItem: any) => void;
@@ -99,7 +99,7 @@ export class BaseKubeTable<T> extends BaseComponent<ITableComponentProperties<T>
         );
     }
 
-    public static renderTableCell(rowIndex: number, columnIndex: number, tableColumn: ITableColumn<any>, itemToRender: React.ReactNode, statusProps?:IResourceStatusProps): JSX.Element {
+    public static renderTableCell(rowIndex: number, columnIndex: number, tableColumn: ITableColumn<any>, itemToRender: React.ReactNode, statusProps?: IResourceStatusProps): JSX.Element {
         return (
             <SimpleTableCell columnIndex={columnIndex} tableColumn={tableColumn} key={"col-" + columnIndex}>
                 {statusProps && <ResourceStatus {...statusProps} />}
@@ -121,8 +121,8 @@ export class BaseKubeTable<T> extends BaseComponent<ITableComponentProperties<T>
                         <span className="overflow-ellipsis">{subText}</span>
                     </Tooltip>
                 </div>
-                }
-                iconProps={statusProps ? {render: (key:string | undefined) => <ResourceStatus {...statusProps} />} :{}}
+            }
+                iconProps={statusProps ? { render: (key: string | undefined) => <ResourceStatus {...statusProps} /> } : {}}
                 key={"col-" + columnIndex} />
         );
     }

--- a/src/WebUI/Common/Webplatform.scss
+++ b/src/WebUI/Common/Webplatform.scss
@@ -5,6 +5,12 @@
     padding-bottom: 0px;
 }
 
+.pod-overview-key .bolt-table-cell-content,
+.pod-overview-value .bolt-table-cell-content{
+    padding-top: 5px;
+    padding-bottom: 5px;
+}
+
 .workload-details-card {
     .bolt-table-cell-content {
         padding-top: 0px;

--- a/src/WebUI/Pods/PodOverview.tsx
+++ b/src/WebUI/Pods/PodOverview.tsx
@@ -47,9 +47,7 @@ export class PodOverview extends BaseComponent<IPodOverviewProps> {
 
         let image: string = "";
         if (pod.spec && pod.spec.containers && pod.spec.containers.length > 0) {
-            const containersCount = pod.spec.containers.length;
-            const defaultImage = pod.spec.containers[0].image;
-            image = containersCount > 1 ? localeFormat(Resources.MoreImagesText, defaultImage, containersCount - 1) : defaultImage;
+            image = Utils.getImageText(pod.spec.containers);
         }
 
         const tableItems = new ArrayItemProvider<any>([

--- a/src/WebUI/Pods/PodsDetails.tsx
+++ b/src/WebUI/Pods/PodsDetails.tsx
@@ -15,6 +15,7 @@ import { PodsRightPanel } from "./PodsRightPanel";
 export interface IPodsDetailsProperties extends IVssComponentProperties {
     pods: V1Pod[];
     parentName: string;
+    onBackButtonClick?: () => void;
 }
 
 export interface IPodsDetailsState {
@@ -39,7 +40,8 @@ export class PodsDetails extends BaseComponent<IPodsDetailsProperties, IPodsDeta
             <PodsLeftPanel
                 pods={this.props.pods}
                 parentName={this.props.parentName}
-                onSelectionChange={this._onPodSelectionChange} />
+                onSelectionChange={this._onPodSelectionChange}
+                onBackButtonClick={this.props.onBackButtonClick} />
         );
 
         const rightPanel = (selectedPod ?

--- a/src/WebUI/Pods/PodsLeftPanel.scss
+++ b/src/WebUI/Pods/PodsLeftPanel.scss
@@ -13,7 +13,7 @@
         padding-left: 20px;
         margin-top: 15px;
         margin-bottom: 20px;
-        font-size: 14px;
+        font-size: $fontSizeM;
         font-weight: $fontWeightSemiBold;
     }
 }

--- a/src/WebUI/Pods/PodsLeftPanel.scss
+++ b/src/WebUI/Pods/PodsLeftPanel.scss
@@ -4,13 +4,15 @@
     margin-top: 15px;
 
     .pod-left-panel-header {
-        padding-left: 20px;
+        .pod-left-panel-back-button {
+            cursor: pointer;
+        }
     }
 
     .pod-left-panel-table-header {
         padding-left: 20px;
-        margin-top: 30px;
-        margin-bottom: 30px;
+        margin-top: 15px;
+        margin-bottom: 20px;
         font-size: 14px;
         font-weight: $fontWeightSemiBold;
     }

--- a/src/WebUI/Pods/PodsLeftPanel.tsx
+++ b/src/WebUI/Pods/PodsLeftPanel.tsx
@@ -9,10 +9,12 @@ import { Card } from "azure-devops-ui/Card";
 import { ITableRow } from "azure-devops-ui/Components/Table/Table.Props";
 import { format } from "azure-devops-ui/Core/Util/String";
 import { Duration } from "azure-devops-ui/Duration";
-import { TitleSize } from "azure-devops-ui/Header";
 import { LabelGroup, WrappingBehavior } from "azure-devops-ui/Label";
 import { IStatusProps, Statuses } from "azure-devops-ui/Status";
 import { ITableColumn, Table } from "azure-devops-ui/Table";
+import { ListSelection, IListSelection } from "azure-devops-ui/List";
+import { Button } from "azure-devops-ui/Button";
+import { Header, IHeaderProps, TitleSize } from "azure-devops-ui/Header";
 import { ArrayItemProvider } from "azure-devops-ui/Utilities/Provider";
 import * as React from "react";
 import { BaseKubeTable } from "../Common/BaseKubeTable";
@@ -36,6 +38,7 @@ export interface IPodsLeftPanelProperties extends IVssComponentProperties {
     pods: V1Pod[];
     parentName: string;
     onSelectionChange?: (event: React.SyntheticEvent<HTMLElement>, selectedItem: V1Pod) => void;
+    onBackButtonClick?: () => void;
 }
 
 export class PodsLeftPanel extends BaseComponent<IPodsLeftPanelProperties> {
@@ -48,6 +51,11 @@ export class PodsLeftPanel extends BaseComponent<IPodsLeftPanelProperties> {
         );
     }
 
+    public componentDidMount() {
+        // Select the first pod in left panel by default
+        this._selection.select(0);
+    }
+
     private _onSelectionChange = (event: React.SyntheticEvent<HTMLElement>, tableRow: ITableRow<any>) => {
         if (this.props.onSelectionChange) {
             this.props.onSelectionChange(event, this.props.pods[tableRow.index]);
@@ -55,8 +63,13 @@ export class PodsLeftPanel extends BaseComponent<IPodsLeftPanelProperties> {
     }
 
     private _getHeader(): JSX.Element | null {
-        /* ToDo :: Add back button here when we have support for the same */
-        return (<h2 className="pod-left-panel-header">{this.props.parentName}</h2>);
+        return (
+            <Header
+                title={this.props.parentName}
+                titleIconProps={{ iconName: "Back", onClick: this.props.onBackButtonClick, className: "pod-left-panel-back-button" }}
+                titleSize={TitleSize.Large}
+                className={"pod-left-panel-header"}
+            />);
     }
 
     private _getPodsList(): JSX.Element | null {
@@ -83,7 +96,7 @@ export class PodsLeftPanel extends BaseComponent<IPodsLeftPanelProperties> {
                         showLines={true}
                         singleClickActivation={false}
                         onSelect={this._onSelectionChange}
-                        //focuszoneProps={{focusOnMount: true}}
+                        selection={this._selection}
                     />
                 </div> : null
         );
@@ -125,6 +138,9 @@ export class PodsLeftPanel extends BaseComponent<IPodsLeftPanelProperties> {
                 statusDescription={pod.metadata.name}
             />
         );
+
         return BaseKubeTable.renderTableCell(rowIndex, columnIndex, tableColumn, itemToRender);
     }
+
+    private _selection: IListSelection = new ListSelection();
 }

--- a/src/WebUI/Pods/PodsRightPanel.scss
+++ b/src/WebUI/Pods/PodsRightPanel.scss
@@ -5,6 +5,6 @@
     margin-top: 15px;
 
     .pod-right-panel-header {
-        padding-left: 12px;
+        padding-left: 8px;
     }
 }

--- a/src/WebUI/Pods/PodsRightPanel.tsx
+++ b/src/WebUI/Pods/PodsRightPanel.tsx
@@ -12,6 +12,7 @@ import { PodsRightPanelTabsKeys } from "../Constants";
 import { IVssComponentProperties } from "../Types";
 import "./PodsRightPanel.scss";
 import { PodOverview } from "./PodOverview";
+import { Header, IHeaderProps, TitleSize } from "azure-devops-ui/Header";
 
 export interface IPodRightPanelProps extends IVssComponentProperties {
     pod: V1Pod;
@@ -64,7 +65,12 @@ export class PodsRightPanel extends BaseComponent<IPodRightPanelProps, IPodsRigh
     }
 
     private _getHeader(): JSX.Element | null {
-        return (<h2 className="pod-right-panel-header">{(this.props.pod.metadata && this.props.pod.metadata.name) || ""}</h2>);
+        return (
+            <Header
+                title={(this.props.pod.metadata && this.props.pod.metadata.name) || ""}
+                titleSize={TitleSize.Large}
+                className={"pod-right-panel-header"}
+            />);
     }
 
     private _onSelectedTabChanged = (selectedTab: string): void => {

--- a/src/WebUI/Services/ServiceDetails.tsx
+++ b/src/WebUI/Services/ServiceDetails.tsx
@@ -66,6 +66,7 @@ export class ServiceDetails extends BaseComponent<IServiceDetailsProperties, ISe
             return (<PodsDetails
                 pods={this.state.pods}
                 parentName={serviceName}
+                onBackButtonClick={this._setSelectedPodStateFalse}
             />);
         }
 
@@ -214,6 +215,13 @@ export class ServiceDetails extends BaseComponent<IServiceDetailsProperties, ISe
         this.setState({
             showSelectedPod: true,
             selectedPod: pod
+        });
+    }
+
+    private _setSelectedPodStateFalse = () => {
+        this.setState({
+            showSelectedPod: false,
+            selectedPod: null
         });
     }
 

--- a/src/WebUI/Utils.ts
+++ b/src/WebUI/Utils.ts
@@ -100,10 +100,7 @@ export class Utils {
             && podTemplate.spec
             && podTemplate.spec.containers
             && podTemplate.spec.containers.length > 0) {
-            const containersCount = podTemplate.spec.containers.length;
-            const defaultImage = podTemplate.spec.containers[0].image;
-            const imageText: string = containersCount > 1 ? localeFormat(Resources.MoreImagesText, defaultImage, containersCount - 1) : defaultImage;
-            return imageText;
+            return this.getImageText(podTemplate.spec.containers);
         }
 
         return null;
@@ -122,10 +119,11 @@ export class Utils {
 
         const keys = Object.keys(imageCountMap);
         if (keys.length > 1) {
-            imageString = localeFormat("{0} and {1} more", keys[0], keys.length - 1);
+            imageString = localeFormat(Resources.MoreImagesText, keys[0], keys.length - 1);
         } else {
             imageString = keys[0];
         }
+        
         return imageString;
     }
 }

--- a/src/WebUI/WorkLoads/WorkloadDetails.scss
+++ b/src/WebUI/WorkLoads/WorkloadDetails.scss
@@ -1,7 +1,7 @@
 @import "../Common/Common.scss";
 
 .workload-details-column-header {
-    font-size: 14px;
+    font-size: $fontSizeM;
 }
 
 .workload-details-primary-text {

--- a/src/WebUI/WorkLoads/WorkloadDetails.tsx
+++ b/src/WebUI/WorkLoads/WorkloadDetails.tsx
@@ -57,6 +57,7 @@ export class WorkloadDetails extends BaseComponent<IWorkloadDetailsProperties, I
             return (<PodsDetails
                 pods={this.state.pods}
                 parentName={parentName}
+                onBackButtonClick={this._setSelectedPodStateFalse}
             />);
         }
 
@@ -93,6 +94,13 @@ export class WorkloadDetails extends BaseComponent<IWorkloadDetailsProperties, I
         }
 
         return null;
+    }
+
+    private _setSelectedPodStateFalse = () => {
+        this.setState({
+            showSelectedPod: false,
+            selectedPod: null
+        });
     }
 
     private static _getColumns(): ITableColumn<any>[] {


### PR DESCRIPTION
Added back button in PodDetails view (Replaced the HTML header with vssui header)
And handling selection in pods list in left panel
![image](https://user-images.githubusercontent.com/12389221/53241603-2befb680-36c8-11e9-8b8c-a21afff6cf3f.png)
