### PR TITLE
Adding history capability to Kube UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -143,6 +143,12 @@
         "@types/node": "10.12.18"
       }
     },
+    "@types/history": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.2.tgz",
+      "integrity": "sha512-ui3WwXmjTaY73fOQ3/m3nnajU/Orhi6cEu5rzX+BrAAJxa3eITXZ5ch9suPqtM03OWhAHhPSyBGCN4UKoxO20Q==",
+      "dev": true
+    },
     "@types/jest": {
       "version": "23.3.10",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.10.tgz",
@@ -163,6 +169,12 @@
       "version": "15.5.6",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.6.tgz",
       "integrity": "sha512-ZBFR7TROLVzCkswA3Fmqq+IIJt62/T7aY/Dmz+QkU7CaW2QFqAitCE8Ups7IzmGhcN1YWMBT4Qcoc07jU9hOJQ==",
+      "dev": true
+    },
+    "@types/query-string": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@types/query-string/-/query-string-6.2.0.tgz",
+      "integrity": "sha512-dnYqKg7eZ+t7ZhCuBtwLxjqON8yXr27hiu3zXfPqxfJSbWUZNwwISE0BJUxghlcKsk4lZSp7bdFSJBJVNWBfmA==",
       "dev": true
     },
     "@types/react": {
@@ -2005,8 +2017,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -3880,6 +3891,18 @@
         "minimalistic-assert": "1.0.1"
       }
     },
+    "history": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
+      "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
+      "requires": {
+        "invariant": "2.2.4",
+        "loose-envify": "1.4.0",
+        "resolve-pathname": "2.2.0",
+        "value-equal": "0.4.0",
+        "warning": "3.0.0"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -4065,7 +4088,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "1.4.0"
       }
@@ -7480,6 +7502,15 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
+    "query-string": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.2.0.tgz",
+      "integrity": "sha512-5wupExkIt8RYL4h/FE+WTg3JHk62e6fFPWtAZA9J5IWK1PfTfKkMS93HBUHcFpeYi9KsY5pFbh+ldvEyaz5MyA==",
+      "requires": {
+        "decode-uri-component": "0.2.0",
+        "strict-uri-encode": "2.0.0"
+      }
+    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -7900,6 +7931,11 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
+    },
+    "resolve-pathname": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
+      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -8654,6 +8690,11 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-length": {
       "version": "2.0.0",
@@ -9695,6 +9736,11 @@
         "spdx-expression-parse": "3.0.0"
       }
     },
+    "value-equal": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
+      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -9730,6 +9776,14 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.11"
+      }
+    },
+    "warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "requires": {
+        "loose-envify": "1.4.0"
       }
     },
     "watch": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
   "dependencies": {
     "@kubernetes/client-node": "~0.8.1",
     "azure-devops-ui": "^1.148.0",
+    "history": "^4.7.2",
+    "query-string": "^6.2.0",
     "react": "~16.3.2",
     "react-dom": "~16.3.2"
   },
@@ -44,7 +46,9 @@
     "@types/enzyme": "^3.1.15",
     "@types/enzyme-adapter-react-16": "^1.0.3",
     "@types/enzyme-to-json": "^1.5.2",
+    "@types/history": "^4.7.2",
     "@types/jest": "^23.3.10",
+    "@types/query-string": "^6.2.0",
     "@types/react": "^16.7.13",
     "@types/react-dom": "^16.0.11",
     "base64-inline-loader": "^1.1.1",

--- a/src/WebUI/Common/KubeSummary.tsx
+++ b/src/WebUI/Common/KubeSummary.tsx
@@ -3,7 +3,7 @@
     Licensed under the MIT license.
 */
 
-import { V1DaemonSet, V1ObjectMeta, V1Pod, V1PodTemplateSpec, V1ReplicaSet, V1StatefulSet } from "@kubernetes/client-node";
+import { V1DaemonSet, V1ObjectMeta, V1Pod, V1PodTemplateSpec, V1ReplicaSet, V1StatefulSet, V1ReplicaSetList, V1StatefulSetList, V1DaemonSetList, V1ServiceList, V1Service } from "@kubernetes/client-node";
 import { BaseComponent, css } from "@uifabric/utilities";
 import { ObservableValue } from "azure-devops-ui/Core/Observable";
 import { localeFormat } from "azure-devops-ui/Core/Util/String";
@@ -14,7 +14,6 @@ import { Surface, SurfaceBackground } from "azure-devops-ui/Surface";
 import { Page } from "azure-devops-ui/Page"
 import { Filter, FILTER_CHANGE_EVENT, IFilterState } from "azure-devops-ui/Utilities/Filter";
 import * as React from "react";
-import { IKubeService } from "../../Contracts/Contracts";
 import { SelectedItemKeys, ServicesEvents, WorkloadsEvents, HyperLinks } from "../Constants";
 import { ActionsCreatorManager } from "../FluxCommon/ActionsCreatorManager";
 import { StoreManager } from "../FluxCommon/StoreManager";
@@ -33,6 +32,10 @@ import "./KubeSummary.scss";
 import { KubeZeroData, IKubeZeroDataProps } from "./KubeZeroData";
 import { Utils } from "../Utils";
 import { Header, TitleSize } from "azure-devops-ui/Header";
+import { IKubeService } from "../../Contracts/Contracts";
+import { createBrowserHistory, History, UnregisterCallback, Action, Location } from "history";
+import * as queryString from "query-string";
+import { ServicesTable } from "../Services/ServicesTable";
 
 const workloadsPivotItemKey: string = "workloads";
 const servicesPivotItemKey: string = "services";
@@ -68,6 +71,7 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
         servicesFilter.subscribe(this._onSvcFilterApplied, FILTER_CHANGE_EVENT);
 
         this._setSelectedKeyPodsViewMap();
+        this._populateObjectFinder();
 
         // Take namespace from deployment store and rest from selection store
         this.state = {
@@ -96,6 +100,8 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
 
         this._workloadsStore.addListener(WorkloadsEvents.WorkloadsFoundEvent, this._onDataFound);
         this._servicesStore.addListener(ServicesEvents.ServicesFoundEvent, this._onDataFound);
+
+        this._historyService = createBrowserHistory();
     }
 
     public render(): React.ReactNode {
@@ -112,11 +118,38 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
         );
     }
 
+    public componentDidMount(): void {
+        // This needs to be called after the data is loaded so that we can decide which object is selected as per the URL
+        setTimeout(() => {
+            this._updateStateFromHistory(queryString.parse(this._historyService.location.search));
+            this._historyUnlisten = this._historyService.listen(this._onHistoryChanged);            
+        }, 100);
+    }
+
     public componentWillUnmount(): void {
         this._selectionStore.removeChangedListener(this._onSelectionStoreChanged);
         this._workloadsStore.removeListener(WorkloadsEvents.DeploymentsFetchedEvent, this._setNamespaceOnDeploymentsFetched);
         this._workloadsStore.removeListener(WorkloadsEvents.WorkloadsFoundEvent, this._onDataFound);
         this._servicesStore.removeListener(ServicesEvents.ServicesFoundEvent, this._onDataFound);
+        this._historyUnlisten();
+    }
+
+    private _updateStateFromHistory = (routeValues: queryString.OutputParams): void => {
+        if (routeValues["type"] && routeValues["uid"])
+        {
+            const typeName: string = routeValues["type"] as string;
+            const objectId: string = routeValues["uid"] as string;
+            const selectedItem = this._objectFinder[typeName](objectId);
+            this.setState({selectedItemType: typeName, selectedItem: selectedItem, showSelectedItem: true});
+        }
+        else {
+            this.setState({selectedItemType: "", selectedItem: undefined, showSelectedItem: false});
+        }
+    };
+
+    private _onHistoryChanged = (location: Location, action: Action): void => {      
+        let routeValues: queryString.OutputParams = queryString.parse(location.search);
+        this._updateStateFromHistory(routeValues);
     }
 
     private _setNamespaceOnDeploymentsFetched = (): void => {
@@ -218,6 +251,16 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
         this._selectedItemViewMap[SelectedItemKeys.ReplicaSetKey] = (item) => this._getWorkoadPodsViewComponent(item.metadata, item.spec && item.spec.template, item.kind || "ReplicaSet", item.status.availableReplicas, item.status.replicas);
     }
 
+    private _populateObjectFinder() {
+        this._objectFinder[SelectedItemKeys.ReplicaSetKey] = (uid) => (this._workloadsStore.getState().replicaSetList as V1ReplicaSetList).items.filter(r => r.metadata.uid == uid)[0];
+        this._objectFinder[SelectedItemKeys.StatefulSetKey] = (uid) => (this._workloadsStore.getState().statefulSetList as V1StatefulSetList).items.filter(r => r.metadata.uid == uid)[0];
+        this._objectFinder[SelectedItemKeys.DaemonSetKey] = (uid) => (this._workloadsStore.getState().daemonSetList as V1DaemonSetList).items.filter(r => r.metadata.uid == uid)[0];
+        this._objectFinder[SelectedItemKeys.ServiceItemKey] = (uid) => {
+            let filteredServices: V1Service[] =  (this._servicesStore.getState().serviceList as V1ServiceList).items.filter(r => r.metadata.uid == uid);
+            return ServicesTable.getServiceItems(filteredServices)[0];
+        }
+    }
+
     private _getFiterHeaderBar(): JSX.Element {
         return (
             <div>
@@ -243,8 +286,11 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
     }
 
     private _selectedItemViewMap: { [selectedItemKey: string]: (selectedItem: any) => JSX.Element | null } = {};
+    private _objectFinder: { [selectedItemKey: string]: (name: string) => V1ReplicaSet | V1DaemonSet | V1StatefulSet | IServiceItem } = {};
     private _selectionStore: SelectionStore;
     private _workloadsActionCreator: WorkloadsActionsCreator;
     private _workloadsStore: WorkloadsStore;
     private _servicesStore: ServicesStore;
+    private _historyService: History;
+    private _historyUnlisten: UnregisterCallback;
 }

--- a/src/WebUI/Pods/PodsTable.tsx
+++ b/src/WebUI/Pods/PodsTable.tsx
@@ -120,7 +120,13 @@ export class PodsTable extends BaseComponent<IPodsTableProperties> {
             this.props.onItemActivated(event, selectedItem);
         }
         else if (selectedItem) {
-            ActionsHubManager.GetActionsHub<SelectionActions>(SelectionActions).selectItem.invoke({ item: selectedItem, showSelectedItem: true, selectedItemType: SelectedItemKeys.OrphanPodKey });
+            ActionsHubManager.GetActionsHub<SelectionActions>(SelectionActions).selectItem.invoke(
+                { 
+                    item: selectedItem, 
+                    itemUID: selectedItem.metadata.uid,
+                    showSelectedItem: true, 
+                    selectedItemType: SelectedItemKeys.OrphanPodKey 
+                });
         }
     }
 

--- a/src/WebUI/Selection/SelectionActionCreator.ts
+++ b/src/WebUI/Selection/SelectionActionCreator.ts
@@ -1,0 +1,37 @@
+/*
+    Copyright (c) Microsoft Corporation. All rights reserved.
+    Licensed under the MIT license.
+*/
+
+import { ActionCreatorBase } from "../FluxCommon/Actions";
+import { ActionsHubManager } from "../FluxCommon/ActionsHubManager";
+import { createBrowserHistory, History } from "history";
+import * as queryString from "query-string";
+import { SelectionActions, ISelectionPayload } from "./SelectionActions";
+
+export class SelectionActionsCreator extends ActionCreatorBase {
+
+    public static getKey(): string {
+        return "selection-actionscreator";
+    }
+
+    public initialize(instanceId?: string): void {
+        this._historyService = createBrowserHistory();
+        this._actions = ActionsHubManager.GetActionsHub<SelectionActions>(SelectionActions);
+    }
+
+    public selectItem(payload: ISelectionPayload): void {
+        let routeValues: queryString.OutputParams = queryString.parse(this._historyService.location.search);
+        routeValues["type"] = payload.selectedItemType;
+        routeValues["uid"] = payload.itemUID;
+        this._historyService.push({
+            pathname: this._historyService.location.pathname,
+            search: queryString.stringify(routeValues)
+        });
+        
+        this._actions.selectItem.invoke(payload);
+    }
+
+    private _actions: SelectionActions;
+    private _historyService: History;
+}

--- a/src/WebUI/Selection/SelectionActions.ts
+++ b/src/WebUI/Selection/SelectionActions.ts
@@ -9,6 +9,7 @@ import { IServiceItem } from "../Types";
 
 export interface ISelectionPayload {
     item: V1ReplicaSet | V1DaemonSet | V1StatefulSet | IServiceItem | V1Pod;
+    itemUID: string;
     showSelectedItem: boolean;
     selectedItemType: string;
 }

--- a/src/WebUI/Selection/SelectionStore.ts
+++ b/src/WebUI/Selection/SelectionStore.ts
@@ -4,7 +4,6 @@
 */
 
 import { StoreBase } from "../FluxCommon/Store";
-import { StoreManager } from "../FluxCommon/StoreManager";
 import { ActionsHubManager } from "../FluxCommon/ActionsHubManager";
 import { V1DeploymentList, V1ReplicaSet, V1Pod, V1DaemonSet, V1StatefulSet } from "@kubernetes/client-node";
 import { SelectionActions, ISelectionPayload } from "./SelectionActions";

--- a/src/WebUI/Types.d.ts
+++ b/src/WebUI/Types.d.ts
@@ -53,6 +53,7 @@ export interface IDeploymentReplicaSetMap {
 
 export interface ISetWorkloadTypeItem {
     name: string;
+    uid: string;
     kind: string;
     image: string;
     desiredPodCount: number;

--- a/src/WebUI/WorkLoads/OtherWorkloadsTable.tsx
+++ b/src/WebUI/WorkLoads/OtherWorkloadsTable.tsx
@@ -21,12 +21,11 @@ import { WorkloadsStore } from "./WorkloadsStore";
 import { ActionsCreatorManager } from "../FluxCommon/ActionsCreatorManager";
 import { StoreManager } from "../FluxCommon/StoreManager";
 import { WorkloadsEvents, SelectedItemKeys } from "../Constants";
-import { SelectionStore } from "../Selection/SelectionStore";
-import { SelectionActions } from "../Selection/SelectionActions";
-import { ActionsHubManager } from "../FluxCommon/ActionsHubManager";
+import { ISelectionPayload } from "../Selection/SelectionActions";
 import { KubeResourceType } from "../../Contracts/KubeServiceBase";
 import { Link } from "azure-devops-ui/Link";
 import { format } from "azure-devops-ui/Core/Util/String";
+import { SelectionActionsCreator } from "../Selection/SelectionActionCreator";
 
 const setNameKey = "otherwrkld-name-key";
 const imageKey = "otherwrkld-image-key";
@@ -51,6 +50,7 @@ export class OtherWorkloads extends BaseComponent<IOtherWorkloadsProperties, IOt
         super(props, {});
 
         this._actionCreator = ActionsCreatorManager.GetActionCreator<WorkloadsActionsCreator>(WorkloadsActionsCreator);
+        this._selectionActionCreator = ActionsCreatorManager.GetActionCreator<SelectionActionsCreator>(SelectionActionsCreator);
         this._store = StoreManager.GetStore<WorkloadsStore>(WorkloadsStore);
 
         this.state = { statefulSetList:[], daemonSetList:[], replicaSets:[] };
@@ -115,7 +115,14 @@ export class OtherWorkloads extends BaseComponent<IOtherWorkloadsProperties, IOt
 
     private _openStatefulSetItem = (event: React.SyntheticEvent<HTMLElement>, tableRow: ITableRow<any>, selectedItem: ISetWorkloadTypeItem) => {
         if (selectedItem) {
-            ActionsHubManager.GetActionsHub<SelectionActions>(SelectionActions).selectItem.invoke({ item: selectedItem.payload, showSelectedItem: true, selectedItemType: selectedItem.kind });
+            const payload: ISelectionPayload = { 
+                item: selectedItem.payload, 
+                itemUID: selectedItem.uid,
+                showSelectedItem: true, 
+                selectedItemType: selectedItem.kind
+            };
+
+            this._selectionActionCreator.selectItem(payload);
         }
     }
 
@@ -203,6 +210,7 @@ export class OtherWorkloads extends BaseComponent<IOtherWorkloadsProperties, IOt
         this._showType(KubeResourceType.StatefulSets) && this.state.statefulSetList.forEach((set) => {
             data.push({
                 name: set.metadata.name,
+                uid: set.metadata.uid,
                 kind: SelectedItemKeys.StatefulSetKey,
                 creationTimeStamp: set.metadata.creationTimestamp,
                 image: Utils.getImageText(set.spec.template.spec),
@@ -215,6 +223,7 @@ export class OtherWorkloads extends BaseComponent<IOtherWorkloadsProperties, IOt
         this._showType(KubeResourceType.DaemonSets) && this.state.daemonSetList.forEach((set) => {
             data.push({
                 name: set.metadata.name,
+                uid: set.metadata.uid,
                 kind: SelectedItemKeys.DaemonSetKey,
                 creationTimeStamp: set.metadata.creationTimestamp,
                 image: Utils.getImageText(set.spec.template.spec),
@@ -227,6 +236,7 @@ export class OtherWorkloads extends BaseComponent<IOtherWorkloadsProperties, IOt
         this._showType(KubeResourceType.ReplicaSets) && this.state.replicaSets.forEach((set) => {
             data.push({
                 name: set.metadata.name,
+                uid: set.metadata.uid,
                 kind: SelectedItemKeys.ReplicaSetKey,
                 creationTimeStamp: set.metadata.creationTimestamp,
                 image: Utils.getImageText(set.spec.template.spec),
@@ -256,4 +266,5 @@ export class OtherWorkloads extends BaseComponent<IOtherWorkloadsProperties, IOt
 
     private _store: WorkloadsStore;
     private _actionCreator: WorkloadsActionsCreator;
+    private _selectionActionCreator: SelectionActionsCreator;
 }

--- a/src/WebUI/WorkLoads/WorkloadsActionsCreator.ts
+++ b/src/WebUI/WorkLoads/WorkloadsActionsCreator.ts
@@ -6,7 +6,6 @@
 import { ActionCreatorBase, Action } from "../FluxCommon/Actions";
 import { ActionsHubManager } from "../FluxCommon/ActionsHubManager";
 import { IKubeService } from "../../Contracts/Contracts";
-import { V1DeploymentList, V1ReplicaSet, V1ReplicaSetList, V1DaemonSetList, V1StatefulSetList, V1PodList, V1Pod, V1DaemonSet, V1StatefulSet, V1PodTemplateSpec, V1ObjectMeta } from "@kubernetes/client-node";
 import { WorkloadsActions } from "./WorkloadsActions";
 
 export class WorkloadsActionsCreator extends ActionCreatorBase {

--- a/src/WebUI/WorkLoads/WorkloadsPivot.tsx
+++ b/src/WebUI/WorkLoads/WorkloadsPivot.tsx
@@ -25,6 +25,7 @@ import { OtherWorkloads } from "../Workloads/OtherWorkloadsTable";
 import { WorkloadsFilterBar } from "./WorkloadsFilterBar";
 import { WorkloadsStore } from "./WorkloadsStore";
 import { HyperLinks } from "../Constants";
+import { WorkloadsActionsCreator } from "./WorkloadsActionsCreator";
 import "./WorkloadsPivot.scss";
 
 export interface IWorkloadsPivotState {
@@ -43,6 +44,7 @@ export class WorkloadsPivot extends BaseComponent<IWorkloadsPivotProps, IWorkloa
     constructor(props: IWorkloadsPivotProps) {
         super(props, {});
 
+        this._workloadsActionCreator = ActionsCreatorManager.GetActionCreator<WorkloadsActionsCreator>(WorkloadsActionsCreator);
         this._podsActionCreator = ActionsCreatorManager.GetActionCreator<PodsActionsCreator>(PodsActionsCreator);
         this._workloadsStore = StoreManager.GetStore<WorkloadsStore>(WorkloadsStore);
         // Initialize pods store as pods list will be required in workloadPodsView on item selection
@@ -51,6 +53,8 @@ export class WorkloadsPivot extends BaseComponent<IWorkloadsPivotProps, IWorkloa
         this.state = {
             workloadResourceSize: 0
         };
+        
+        this._workloadsActionCreator.getDeployments(this.props.kubeService);
 
         // Fetch all pods in parent component as the podList is required in selected workload pods view
         this._podsActionCreator.getPods(this.props.kubeService);
@@ -134,7 +138,7 @@ export class WorkloadsPivot extends BaseComponent<IWorkloadsPivotProps, IWorkloa
 
     private _showComponent(resourceType: KubeResourceType): boolean {
         const selections: KubeResourceType[] = this._getTypeFilterValue();
-        // if no selections are made, show all components
+        // if no filter selections are made, show all components
         if (selections.length > 0) {
             return selections.indexOf(resourceType) != -1;
         }
@@ -154,5 +158,6 @@ export class WorkloadsPivot extends BaseComponent<IWorkloadsPivotProps, IWorkloa
     }
 
     private _workloadsStore: WorkloadsStore;
+    private _workloadsActionCreator: WorkloadsActionsCreator;
     private _podsActionCreator: PodsActionsCreator;
 }

--- a/src/WebUI/WorkLoads/WorkloadsStore.ts
+++ b/src/WebUI/WorkLoads/WorkloadsStore.ts
@@ -4,7 +4,6 @@
 */
 
 import { StoreBase } from "../FluxCommon/Store";
-import { StoreManager } from "../FluxCommon/StoreManager";
 import { ActionsHubManager } from "../FluxCommon/ActionsHubManager";
 import { V1DeploymentList, V1ReplicaSetList, V1DaemonSetList, V1StatefulSetList, V1PodList, V1Pod } from "@kubernetes/client-node";
 import { WorkloadsActions } from "./WorkloadsActions";


### PR DESCRIPTION
- Added two packages history, query-string for this feature.
- The selectedItem name & type will now be part of the URL
- We can now land on either landing/details pages
- ToDo:
   - Load the appropriate landing/details view upfront when there is no data, based on URL
   - Move data load to the root component so that the view loading decision is taken at root level. (this would help get rid of setTimeout)