### PR TITLE
Minor tweaks in UI

### DIFF
--- a/src/WebUI/Common/KubeFilterBar.tsx
+++ b/src/WebUI/Common/KubeFilterBar.tsx
@@ -40,7 +40,7 @@ export class KubeFilterBar extends BaseComponent<IFilterComponentProperties, {}>
         return (
             <ConditionalChildren renderChildren={this.props.filterToggled}>
                 <FilterBar filter={this.props.filter} className={this.props.className || ""}>
-                    <KeywordFilterBarItem filterItemKey={NameKey} placeholder={localeFormat(Resources.FindByNameText, this.props.keywordPlaceHolder.toLowerCase())} />
+                    <KeywordFilterBarItem filterItemKey={NameKey} placeholder={localeFormat(Resources.FindByNameText, this.props.keywordPlaceHolder)} />
                     <PickListFilterBarItem
                         placeholder={this.props.pickListPlaceHolder}
                         showPlaceholderAsLabel={true}

--- a/src/WebUI/Common/KubeSummary.tsx
+++ b/src/WebUI/Common/KubeSummary.tsx
@@ -239,7 +239,7 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
             primaryText: Resources.StartUsingKubeResourceText,
             className: "zerod-side-align-content"
         }
-        return (KubeZeroData._getDefaultZeroData(zeroDataProps));
+        return (KubeZeroData.getDefaultZeroData(zeroDataProps));
     }
 
     private _selectedItemViewMap: { [selectedItemKey: string]: (selectedItem: any) => JSX.Element | null } = {};

--- a/src/WebUI/Common/KubeZeroData.tsx
+++ b/src/WebUI/Common/KubeZeroData.tsx
@@ -52,7 +52,7 @@ export class KubeZeroData extends BaseComponent<IKubeZeroDataProps> {
         );
     }
 
-    public static _getDefaultZeroData(zeroDataProps: IKubeZeroDataProps): JSX.Element{
+    public static getDefaultZeroData(zeroDataProps: IKubeZeroDataProps): JSX.Element{
         return (
             <KubeZeroData
                 imagePath={require("../../img/zero_data.png")}
@@ -61,7 +61,7 @@ export class KubeZeroData extends BaseComponent<IKubeZeroDataProps> {
         );
     }
 
-    public static _getNoResultsZeroData(): JSX.Element {
+    public static getNoResultsZeroData(): JSX.Element {
         return (
             <KubeZeroData imagePath={require("../../img/zero_data.png")} descriptionText={Resources.NoResultsFoundText} />
         );

--- a/src/WebUI/Common/KubeZeroData.tsx
+++ b/src/WebUI/Common/KubeZeroData.tsx
@@ -9,6 +9,7 @@ import { Card } from "azure-devops-ui/Card";
 import { IVssComponentProperties } from "../Types";
 import { BaseComponent, css } from "@uifabric/utilities/lib";
 import { Link } from "azure-devops-ui/Link";
+import * as Resources from "../Resources";
 import "./Common.scss";
 import "./BaseKubeTable.scss";
 import "./Webplatform.scss";
@@ -57,6 +58,12 @@ export class KubeZeroData extends BaseComponent<IKubeZeroDataProps> {
                 imagePath={require("../../img/zero_data.png")}
                 {...zeroDataProps}
             />
+        );
+    }
+
+    public static _getNoResultsZeroData(): JSX.Element {
+        return (
+            <KubeZeroData imagePath={require("../../img/zero_data.png")} descriptionText={Resources.NoResultsFoundText} />
         );
     }
 

--- a/src/WebUI/Pods/PodsTable.tsx
+++ b/src/WebUI/Pods/PodsTable.tsx
@@ -132,7 +132,7 @@ export class PodsTable extends BaseComponent<IPodsTableProperties> {
     }
 
     private static _renderPodWorkload(rowIndex: number, columnIndex: number, tableColumn: ITableColumn<V1Pod>, pod: V1Pod): JSX.Element {
-        const textToRender = pod.metadata.ownerReferences && pod.metadata.ownerReferences.length > 0 ? pod.metadata.ownerReferences[0].name : ""; 
+        const textToRender = pod && pod.metadata && pod.metadata.ownerReferences && pod.metadata.ownerReferences.length > 0 ? pod.metadata.ownerReferences[0].name : ""; 
         const itemToRender: React.ReactNode = textToRender.length > 0 ? (
             <Link
                 className="fontSizeM text-ellipsis bolt-table-link bolt-table-inline-link"

--- a/src/WebUI/Pods/PodsTable.tsx
+++ b/src/WebUI/Pods/PodsTable.tsx
@@ -132,8 +132,8 @@ export class PodsTable extends BaseComponent<IPodsTableProperties> {
     }
 
     private static _renderPodWorkload(rowIndex: number, columnIndex: number, tableColumn: ITableColumn<V1Pod>, pod: V1Pod): JSX.Element {
-        const textToRender = pod.metadata.ownerReferences.length > 0 ? pod.metadata.ownerReferences[0].name : ""; 
-        const itemToRender: React.ReactNode = (
+        const textToRender = pod.metadata.ownerReferences && pod.metadata.ownerReferences.length > 0 ? pod.metadata.ownerReferences[0].name : ""; 
+        const itemToRender: React.ReactNode = textToRender.length > 0 ? (
             <Link
                 className="fontSizeM text-ellipsis bolt-table-link bolt-table-inline-link"
                 excludeTabStop
@@ -141,7 +141,7 @@ export class PodsTable extends BaseComponent<IPodsTableProperties> {
             >
                 {textToRender}
             </Link>
-        );
+        ): null;
         return BaseKubeTable.renderTableCell(rowIndex, columnIndex, tableColumn, itemToRender);
     }
 

--- a/src/WebUI/Resources.d.ts
+++ b/src/WebUI/Resources.d.ts
@@ -70,3 +70,5 @@ export declare const DeployWorkloads: string;
 export declare const WorkloadsZeroDataText: string;
 export declare const NoPodsForSvcLinkText: string;
 export declare const NoPodsText: string;
+export declare const ServiceText: string;
+export declare const NoResultsFoundText: string;

--- a/src/WebUI/Resources.d.ts
+++ b/src/WebUI/Resources.d.ts
@@ -72,3 +72,4 @@ export declare const NoPodsForSvcLinkText: string;
 export declare const NoPodsText: string;
 export declare const ServiceText: string;
 export declare const NoResultsFoundText: string;
+export declare const WorkloadsFilterText: string;

--- a/src/WebUI/Resources.js
+++ b/src/WebUI/Resources.js
@@ -71,6 +71,7 @@ define("Environments/Providers/Kubernetes/Resources", ["require", "exports"], fu
     exports.WorkloadsZeroDataText = "You can also deploy all kinds of workloads like deployment, replicaset, daemonset etc., and track them in here";
     exports.NoPodsForSvcLinkText = "Learn more about mapping a service";
     exports.NoPodsText = "No pods";
-    exports.ServiceText = "Service";
+    exports.ServiceText = "service";
     exports.NoResultsFoundText = "No results found";
+    exports.WorkloadsFilterText = "workload"; // case sensitive
 });

--- a/src/WebUI/Resources.js
+++ b/src/WebUI/Resources.js
@@ -41,7 +41,7 @@ define("Environments/Providers/Kubernetes/Resources", ["require", "exports"], fu
     exports.NoPodsForSvcText = "This service currently does not map to any pods";
     exports.ExternalIPAllocPending = "External IP allocation pending";
     exports.ExternalIPAllocated = "External IP allocated";
-    exports.FindByNameText = "Find by {0} name";
+    exports.FindByNameText = "Filter by {0} name";
     exports.KindText = "Kind";
     exports.NoItemsText = "No Items found"
     exports.PodDetailsHeader = "Pod details";
@@ -71,4 +71,6 @@ define("Environments/Providers/Kubernetes/Resources", ["require", "exports"], fu
     exports.WorkloadsZeroDataText = "You can also deploy all kinds of workloads like deployment, replicaset, daemonset etc., and track them in here";
     exports.NoPodsForSvcLinkText = "Learn more about mapping a service";
     exports.NoPodsText = "No pods";
+    exports.ServiceText = "Service";
+    exports.NoResultsFoundText = "No results found";
 });

--- a/src/WebUI/Services/ServiceDetails.tsx
+++ b/src/WebUI/Services/ServiceDetails.tsx
@@ -212,7 +212,7 @@ export class ServiceDetails extends BaseComponent<IServiceDetailsProperties, ISe
                 primaryTextClassName: "primary-text",
                 renderOnCard: true
             }
-            return KubeZeroData._getDefaultZeroData(zeroDataProps);
+            return KubeZeroData.getDefaultZeroData(zeroDataProps);
         }
         return (
             <PodsTable

--- a/src/WebUI/Services/ServicesFilterBar.tsx
+++ b/src/WebUI/Services/ServicesFilterBar.tsx
@@ -13,17 +13,17 @@ import "../Common/KubeSummary.scss";
 import * as Resources from "../Resources";
 import { IVssComponentProperties } from "../Types";
 
-export interface IWorkloadsFilterBarProps extends IVssComponentProperties {
+export interface IServiceFilterBarProps extends IVssComponentProperties {
     filter: Filter;
     filterToggled: ObservableValue<boolean>;
     serviceList: V1ServiceList;
 }
 
-export class ServicesFilterBar extends BaseComponent<IWorkloadsFilterBarProps> {
+export class ServicesFilterBar extends BaseComponent<IServiceFilterBarProps> {
     public render(): React.ReactNode {
         return (<KubeFilterBar filter={this.props.filter}
             pickListPlaceHolder={Resources.TypeText}
-            keywordPlaceHolder={Resources.PivotServiceText}
+            keywordPlaceHolder={Resources.ServiceText}
             filterToggled={this.props.filterToggled}
             pickListItemsFn={() => this._generateSvcTypes()}
             listItemsFn={(item: any) => {

--- a/src/WebUI/Services/ServicesPivot.tsx
+++ b/src/WebUI/Services/ServicesPivot.tsx
@@ -106,7 +106,7 @@ export class ServicesPivot extends BaseComponent<IServicesPivotProps, IServicesP
             descriptionText: Resources.StartingUsingServiceText,
             className: "zerod-side-align-content"
         }
-        return (KubeZeroData._getDefaultZeroData(zeroDataProps));
+        return (KubeZeroData.getDefaultZeroData(zeroDataProps));
     }
 
     private _store: ServicesStore;

--- a/src/WebUI/Services/ServicesTable.tsx
+++ b/src/WebUI/Services/ServicesTable.tsx
@@ -22,6 +22,7 @@ import { Utils } from "../Utils";
 import { ServicesActionsCreator } from "./ServicesActionsCreator";
 import { ServicesStore } from "./ServicesStore";
 import "./ServicesTable.scss";
+import { KubeZeroData } from "../Common/KubeZeroData";
 
 const packageKey: string = "package-col";
 const clusterIPKey: string = "cluster-ip-col";
@@ -56,9 +57,9 @@ export class ServicesTable extends BaseComponent<IServicesComponentProperties> {
                 }
                 </div>
             );
+        } else {
+            return KubeZeroData._getNoResultsZeroData();
         }
-
-        return null;
     }
 
     private _openServiceItem = (event: React.SyntheticEvent<HTMLElement>, tableRow: ITableRow<any>, selectedItem: IServiceItem) => {

--- a/src/WebUI/Services/ServicesTable.tsx
+++ b/src/WebUI/Services/ServicesTable.tsx
@@ -58,7 +58,7 @@ export class ServicesTable extends BaseComponent<IServicesComponentProperties> {
                 </div>
             );
         } else {
-            return KubeZeroData._getNoResultsZeroData();
+            return KubeZeroData.getNoResultsZeroData();
         }
     }
 

--- a/src/WebUI/WorkLoads/WorkloadDetails.tsx
+++ b/src/WebUI/WorkLoads/WorkloadDetails.tsx
@@ -163,7 +163,7 @@ export class WorkloadDetails extends BaseComponent<IWorkloadDetailsProperties, I
                 hyperLinkLabel: Resources.LearnMoreText,
                 descriptionText: Resources.NoPodsFoundText
             }
-            return KubeZeroData._getDefaultZeroData(zeroDataProps);
+            return KubeZeroData.getDefaultZeroData(zeroDataProps);
         }
 
         return (

--- a/src/WebUI/WorkLoads/WorkloadsFilterBar.tsx
+++ b/src/WebUI/WorkLoads/WorkloadsFilterBar.tsx
@@ -21,7 +21,7 @@ export interface IWorkloadsFilterBarProps extends IVssComponentProperties {
 export class WorkloadsFilterBar extends BaseComponent<IWorkloadsFilterBarProps> {
     public render(): React.ReactNode {
         return (<KubeFilterBar filter={this.props.filter}
-            keywordPlaceHolder={Resources.PivotWorkloadsText}
+            keywordPlaceHolder={Resources.WorkloadText}
             pickListPlaceHolder={Resources.KindText}
             pickListItemsFn={this._pickListItems}
             listItemsFn={this._listItems}

--- a/src/WebUI/WorkLoads/WorkloadsFilterBar.tsx
+++ b/src/WebUI/WorkLoads/WorkloadsFilterBar.tsx
@@ -21,7 +21,7 @@ export interface IWorkloadsFilterBarProps extends IVssComponentProperties {
 export class WorkloadsFilterBar extends BaseComponent<IWorkloadsFilterBarProps> {
     public render(): React.ReactNode {
         return (<KubeFilterBar filter={this.props.filter}
-            keywordPlaceHolder={Resources.WorkloadText}
+            keywordPlaceHolder={Resources.WorkloadsFilterText}
             pickListPlaceHolder={Resources.KindText}
             pickListItemsFn={this._pickListItems}
             listItemsFn={this._listItems}

--- a/src/WebUI/WorkLoads/WorkloadsPivot.tsx
+++ b/src/WebUI/WorkLoads/WorkloadsPivot.tsx
@@ -150,7 +150,7 @@ export class WorkloadsPivot extends BaseComponent<IWorkloadsPivotProps, IWorkloa
             primaryText: Resources.DeployWorkloads,
             className: "zerod-side-align-content"
         }
-        return (KubeZeroData._getDefaultZeroData(zeroDataProps));
+        return (KubeZeroData.getDefaultZeroData(zeroDataProps));
     }
 
     private _workloadsStore: WorkloadsStore;


### PR DESCRIPTION
Signed-off-by: Rajendra Kolli <rakol@microsoft.com>

This PR contains the following tweaks

* Added condition to render links in pods table only when there is content.
* Added a condition to render a link to workload only if it exists in pod metadata under service details. This condition was observed in the failed clusters.
* Corrected title in filters
* Added no results page for services filter. For workloads some work needs to be done since data is split among two components and is filtered independently while No results page should be rendered by `WorkloadsPivot` component.