### PR TITLE
Make workload link in pods table work

### DIFF
--- a/src/WebUI/Selection/SelectionStore.ts
+++ b/src/WebUI/Selection/SelectionStore.ts
@@ -12,6 +12,7 @@ import { ISelectionPayload, SelectionActions } from "./SelectionActions";
 
 export interface ISelectionStoreState {
     selectedItem: V1ReplicaSet | V1DaemonSet | V1StatefulSet | IServiceItem | V1Pod | IImageDetails | undefined;
+    itemUID: string;
     showSelectedItem: boolean;
     selectedItemType: string;
 }
@@ -24,7 +25,7 @@ export class SelectionStore extends StoreBase {
     public initialize(instanceId?: string): void {
         super.initialize(instanceId);
 
-        this._state = { selectedItem: undefined, showSelectedItem: false, selectedItemType: "" };
+        this._state = { selectedItem: undefined, showSelectedItem: false, selectedItemType: "", itemUID: "" };
 
         this._actions = ActionsHubManager.GetActionsHub<SelectionActions>(SelectionActions);
         this._actions.selectItem.addListener(this._select);
@@ -42,6 +43,7 @@ export class SelectionStore extends StoreBase {
         this._state.selectedItem = payload.item;
         this._state.showSelectedItem = payload.showSelectedItem;
         this._state.selectedItemType = payload.selectedItemType;
+        this._state.itemUID = payload.itemUID;
         this.emitChanged();
     }
 


### PR DESCRIPTION
The link is currently not effective.

Since we aren't using links as links anywhere, switched to a non href based view, where the link is treated like a button. Calling selection action creator to switch the view

We do not have the item that is needed in the pods table. Added logic in kubeSummary to fetch the item from the workloads store, using the uid, if the action payload has an undefined item