### PR TITLE
Show cluster name as subtext in the kubernetes summary heading

### DIFF
--- a/src/WebUI/Common/KubeSummary.tsx
+++ b/src/WebUI/Common/KubeSummary.tsx
@@ -64,6 +64,7 @@ export interface IKubeSummaryProps extends IVssComponentProperties {
     kubeService: IKubeService;
     imageService?: IImageService;
     namespace?: string;
+    clusterName?: string;
     markTTI?: () => void;
     getImageLocation?: (image: KubeImage) => string | undefined;
 }
@@ -203,7 +204,9 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
                     title={this.props.title}
                     titleSize={TitleSize.Large}
                     className={"content-main-heading"}
-                    description={localeFormat(Resources.NamespaceHeadingText, this.state.namespace || "")}
+                    description={this.props.clusterName 
+                        ? localeFormat(Resources.SummaryHeaderSubTextFormat, this.props.clusterName) 
+                        : localeFormat(Resources.NamespaceHeadingText, this.state.namespace || "")}
                 />
                 {pageContent}
             </>

--- a/src/WebUI/Resources.d.ts
+++ b/src/WebUI/Resources.d.ts
@@ -83,3 +83,4 @@ export declare const ImageDetailsHeaderText: string;
 export declare const LayersText: string;
 export declare const CommandText: string;
 export declare const SizeText: string;
+export declare const SummaryHeaderSubTextFormat: string; 

--- a/src/WebUI/Resources.js
+++ b/src/WebUI/Resources.js
@@ -84,4 +84,5 @@ define("Environments/Providers/Kubernetes/Resources", ["require", "exports"], fu
     exports.LayersText = "Layers";
     exports.CommandText = "Command";
     exports.SizeText = "Size";
+    exports.SummaryHeaderSubTextFormat = "{0} (cluster)";
 });


### PR DESCRIPTION
We are changing the subtext of the heading in kubernetes summary to show the cluster name
The cluster name will be passed by the host, and we will display the cluster name

The title will be shown as provided by the host

![image](https://user-images.githubusercontent.com/26616790/55161736-3bad5f80-518c-11e9-8e55-867437bdbaa5.png)


