### PR TITLE
Navigate to pod details when clicked on pods column

### DIFF
--- a/src/WebUI/Common/KubeCardWithTable.tsx
+++ b/src/WebUI/Common/KubeCardWithTable.tsx
@@ -17,6 +17,10 @@ import { IVssComponentProperties } from "../Types";
 import "./KubeCardWithTable.scss";
 import { IResourceStatusProps, ResourceStatus } from "./ResourceStatus";
 import { format } from "azure-devops-ui/Core/Util/String";
+import { V1Pod } from "@kubernetes/client-node";
+import { ActionsCreatorManager } from "../FluxCommon/ActionsCreatorManager";
+import { SelectionActionsCreator } from "../Selection/SelectionActionCreator";
+import { SelectedItemKeys } from "../Constants";
 
 export interface ITableComponentProperties<T> extends IVssComponentProperties {
     className?: string;
@@ -210,20 +214,34 @@ export function renderPodsStatusTableCell(
     tableColumn: ITableColumn<any>,
     podsCountString?: string,
     podsStatusProps?: IStatusProps,
+    onClick?: () => void,
     tooltip?: string
 ): JSX.Element {
+    const content = (
+        <>
+            {podsStatusProps && <Status {...podsStatusProps} size={StatusSize.m} />}
+            <div className="k8s-pods-status-count">{podsCountString}</div>
+        </>
+    );
+
+    const classNames = "fontSizeM flex-center flex-row text-ellipsis";
+
     const itemToRender = podsCountString ? (
         // show tooltip always if specified, otherwise show only when element overflows
         <Tooltip text={tooltip || podsCountString || ""} overflowOnly={!tooltip}>
-            <Link
-                className="fontSizeM flex-center flex-row text-ellipsis bolt-table-link"
-                rel={"noopener noreferrer"}
-                excludeTabStop
-                href="#"
-            >
-                {podsStatusProps && <Status {...podsStatusProps} size={StatusSize.m} />}
-                <div className="k8s-pods-status-count">{podsCountString}</div>
-            </Link>
+            {
+                onClick ? (
+                    <Link
+                        className={classNames + " bolt-table-link"}
+                        rel={"noopener noreferrer"}
+                        excludeTabStop
+                        onClick={() => onClick()}
+                    >
+                        {content}
+                    </Link>)
+                    : (<span className={classNames}>
+                        {content}
+                    </span>)}
         </Tooltip>
     ) : null;
 

--- a/src/WebUI/Common/KubeCardWithTable.tsx
+++ b/src/WebUI/Common/KubeCardWithTable.tsx
@@ -8,19 +8,19 @@ import { CardContent, CustomCard } from "azure-devops-ui/Card";
 import { ITableRow, TableColumnStyle } from "azure-devops-ui/Components/Table/Table.Props";
 import { CustomHeader, HeaderDescription, HeaderTitle, HeaderTitleArea, HeaderTitleRow, TitleSize } from "azure-devops-ui/Header";
 import { Link } from "azure-devops-ui/Link";
-import { IStatusProps, Status, StatusSize } from "azure-devops-ui/Status";
+import { IStatusProps, Status, StatusSize, Statuses } from "azure-devops-ui/Status";
 import { ITableColumn, SimpleTableCell, Table, TwoLineTableCell } from "azure-devops-ui/Table";
 import { Tooltip } from "azure-devops-ui/TooltipEx";
 import { ArrayItemProvider } from "azure-devops-ui/Utilities/Provider";
 import * as React from "react";
-import { IVssComponentProperties } from "../Types";
+import { IVssComponentProperties, IPodDetailsSelectionPropeties } from "../Types";
 import "./KubeCardWithTable.scss";
 import { IResourceStatusProps, ResourceStatus } from "./ResourceStatus";
 import { format } from "azure-devops-ui/Core/Util/String";
-import { V1Pod } from "@kubernetes/client-node";
-import { ActionsCreatorManager } from "../FluxCommon/ActionsCreatorManager";
+import { V1Pod, V1StatefulSet, V1DaemonSet, V1ReplicaSet } from "@kubernetes/client-node";
 import { SelectionActionsCreator } from "../Selection/SelectionActionCreator";
 import { SelectedItemKeys } from "../Constants";
+import { Utils } from "../Utils";
 
 export interface ITableComponentProperties<T> extends IVssComponentProperties {
     className?: string;
@@ -214,8 +214,8 @@ export function renderPodsStatusTableCell(
     tableColumn: ITableColumn<any>,
     podsCountString?: string,
     podsStatusProps?: IStatusProps,
-    onClick?: () => void,
-    tooltip?: string
+    tooltip?: string,
+    onClick?: () => void
 ): JSX.Element {
     const content = (
         <>
@@ -246,4 +246,24 @@ export function renderPodsStatusTableCell(
     ) : null;
 
     return renderTableCell(rowIndex, columnIndex, tableColumn, itemToRender, undefined, podsCountString ? "bolt-table-cell-content-with-link" : "");
+}
+
+export function onPodsColumnClicked(pods: V1Pod[], item: V1ReplicaSet | V1StatefulSet | V1DaemonSet | V1Pod, itemKind: string, selectionActionCreator: SelectionActionsCreator): void {
+    const selectedPod = pods.find(p => Utils.generatePodStatusProps(p.status) === Statuses.Failed) || pods[0];
+    
+    // Item kind "Pod" implies that the type is an orphan pod
+    const properties = itemKind === "Pod" ? undefined : {
+        pods: pods,
+        parentItemKind: itemKind,
+        parentItemName: item.metadata.name,
+        onBackClick: () => { item && selectionActionCreator.selectItem({ item: item, itemUID: item.metadata.uid, selectedItemType: SelectedItemKeys.ReplicaSetKey, showSelectedItem: true }) }
+    } as IPodDetailsSelectionPropeties
+
+    selectionActionCreator.selectItem({
+        item: selectedPod,
+        itemUID: selectedPod.metadata.uid,
+        selectedItemType: itemKind === "Pod" ? SelectedItemKeys.OrphanPodKey : SelectedItemKeys.PodDetailsKey,
+        showSelectedItem: true,
+        properties: properties
+    })
 }

--- a/src/WebUI/Common/KubeSummary.tsx
+++ b/src/WebUI/Common/KubeSummary.tsx
@@ -33,7 +33,7 @@ import { ServiceDetails } from "../Services/ServiceDetails";
 import { ServicesPivot } from "../Services/ServicesPivot";
 import { ServicesStore } from "../Services/ServicesStore";
 import { ServicesTable } from "../Services/ServicesTable";
-import { IServiceItem, IVssComponentProperties } from "../Types";
+import { IServiceItem, IVssComponentProperties, IPodDetailsSelectionPropeties } from "../Types";
 import { Utils } from "../Utils";
 import { WorkloadDetails } from "../Workloads/WorkloadDetails";
 import { WorkloadsActionsCreator } from "../Workloads/WorkloadsActionsCreator";
@@ -42,6 +42,7 @@ import { WorkloadsStore } from "../Workloads/WorkloadsStore";
 import "./KubeSummary.scss";
 import { KubeZeroData } from "./KubeZeroData";
 import { IStatusProps } from "azure-devops-ui/Status";
+import { PodsDetails } from "../Pods/PodsDetails";
 
 const workloadsPivotItemKey: string = "workloads";
 const servicesPivotItemKey: string = "services";
@@ -55,6 +56,7 @@ export interface IKubernetesContainerState {
     selectedItem?: V1ReplicaSet | V1DaemonSet | V1StatefulSet | V1Pod | IServiceItem | IImageDetails;
     showSelectedItem?: boolean;
     selectedItemType?: string;
+    selectedItemProperties?: { [key: string]: string };
     resourceSize: number;
     workloadsFilter: Filter;
     svcFilter: Filter;
@@ -202,14 +204,14 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
         // must be short syntax or React.Fragment, do not use div here to include heading and content.
         return (
             <>
-            <Header
-                title={this.props.title}
-                titleSize={TitleSize.Large}
-                className={"content-main-heading"}
-                description={this.props.clusterName
-                    ? localeFormat(Resources.SummaryHeaderSubTextFormat, this.props.clusterName)
-                    : localeFormat(Resources.NamespaceHeadingText, this.state.namespace || "")}
-            />
+                <Header
+                    title={this.props.title}
+                    titleSize={TitleSize.Large}
+                    className={"content-main-heading"}
+                    description={this.props.clusterName
+                        ? localeFormat(Resources.SummaryHeaderSubTextFormat, this.props.clusterName)
+                        : localeFormat(Resources.NamespaceHeadingText, this.state.namespace || "")}
+                />
                 {pageContent}
             </>
         );
@@ -228,18 +230,18 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
         // must be short syntax or React.Fragment, do not use div here to include heading and content.
         return (
             <>
-            <TabBar
-                selectedTabId={this.state.selectedPivotKey || workloadsPivotItemKey}
-                onSelectedTabChanged={(key: string) => { this.setState({ selectedPivotKey: key }); }}
-                renderAdditionalContent={() => { return this._getFilterHeaderBar(); }}
-                disableSticky={false}
-            >
-                <Tab name={Resources.PivotWorkloadsText} id={workloadsPivotItemKey} />
-                <Tab name={Resources.PivotServiceText} id={servicesPivotItemKey} />
-            </TabBar>
-            <div className="page-content page-content-top k8s-pivot-content">
-                {tabContent}
-            </div>
+                <TabBar
+                    selectedTabId={this.state.selectedPivotKey || workloadsPivotItemKey}
+                    onSelectedTabChanged={(key: string) => { this.setState({ selectedPivotKey: key }); }}
+                    renderAdditionalContent={() => { return this._getFilterHeaderBar(); }}
+                    disableSticky={false}
+                >
+                    <Tab name={Resources.PivotWorkloadsText} id={workloadsPivotItemKey} />
+                    <Tab name={Resources.PivotServiceText} id={servicesPivotItemKey} />
+                </TabBar>
+                <div className="page-content page-content-top k8s-pivot-content">
+                    {tabContent}
+                </div>
             </>
         );
     }
@@ -249,7 +251,7 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
         const selectedItemType = this.state.selectedItemType;
         // ToDo :: Currently for imageDetails type, the selected item will be undefined, hence adding below check. Remove this once we have data from imageService
         if (selectedItemType && (selectedItem || selectedItemType === SelectedItemKeys.ImageDetailsKey) && this._selectedItemViewMap.hasOwnProperty(selectedItemType)) {
-            return this._selectedItemViewMap[selectedItemType](selectedItem);
+            return this._selectedItemViewMap[selectedItemType](selectedItem, this.state.selectedItemProperties);
         }
 
         return null;
@@ -280,7 +282,8 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
             this.setState({
                 showSelectedItem: selectionStoreState.showSelectedItem,
                 selectedItem: item,
-                selectedItemType: selectionStoreState.selectedItemType
+                selectedItemType: selectionStoreState.selectedItemType,
+                selectedItemProperties: selectionStoreState.properties
             });
         }
 
@@ -362,6 +365,35 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
         this._selectedItemViewMap[SelectedItemKeys.ServiceItemKey] = (service) => { return <ServiceDetails service={service} parentKind={service.kind || "Service"} />; };
         this._selectedItemViewMap[SelectedItemKeys.ImageDetailsKey] = (item) => { return <ImageDetails imageDetails={item} onBackButtonClick={this._setSelectionStateFalse} />; };
         this._selectedItemViewMap[SelectedItemKeys.OrphanPodKey] = (pod) => <PodsRightPanel key={pod.metadata.uid} pod={pod} podStatusProps={PodPhaseToStatus[pod.status.phase]} statusTooltip={pod.status.message || pod.status.phase} />;
+        this._selectedItemViewMap[SelectedItemKeys.ReplicaSetKey] = (item) => this._getWorkloadPodsViewComponent(item, "ReplicaSet", (item) => {
+            const status = (item as V1ReplicaSet).status;
+            return Utils.getPodsStatusProps(status.readyReplicas, status.replicas);
+        });
+
+        this._selectedItemViewMap[SelectedItemKeys.StatefulSetKey] = (item) => this._getWorkloadPodsViewComponent(item, "StatefulSet", (item) => {
+            const status = (item as V1StatefulSet).status;
+            return Utils.getPodsStatusProps(status.readyReplicas, status.replicas);
+        });
+
+        this._selectedItemViewMap[SelectedItemKeys.DaemonSetKey] = (item) => this._getWorkloadPodsViewComponent(item, "DaemonSet", (item) => {
+            const status = (item as V1DaemonSet).status;
+            return Utils.getPodsStatusProps(status.numberAvailable, status.desiredNumberScheduled);
+        });
+
+        this._selectedItemViewMap[SelectedItemKeys.ServiceItemKey] = (service) => { return <ServiceDetails service={service} parentKind={service.kind || "Service"} />; };
+        this._selectedItemViewMap[SelectedItemKeys.ImageDetailsKey] = (item) => { return <ImageDetails imageDetails={item} onBackButtonClick={this._setSelectionStateFalse} />; };
+        this._selectedItemViewMap[SelectedItemKeys.OrphanPodKey] = (pod) => <PodsRightPanel key={pod.metadata.uid} pod={pod} podStatusProps={PodPhaseToStatus[pod.status.phase]} statusTooltip={pod.status.message || pod.status.phase} />;
+        this._selectedItemViewMap[SelectedItemKeys.PodDetailsKey] = (item, properties?) => {
+            const selectionProperties = properties as IPodDetailsSelectionPropeties;
+            return selectionProperties ? (
+                <PodsDetails
+                    pods={selectionProperties.pods}
+                    parentKind={selectionProperties.parentItemKind}
+                    parentName={selectionProperties.parentItemName}
+                    onBackButtonClick={selectionProperties.onBackClick}
+                    selectedPod={item} />)
+                : null;
+        }
     }
 
     private _setSelectionStateFalse = () => {
@@ -393,12 +425,12 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
     private _getFilterHeaderBar(): JSX.Element {
         return (
             <>
-            <ConditionalChildren renderChildren={!this.state.selectedPivotKey || this.state.selectedPivotKey === workloadsPivotItemKey}>
-                <HeaderCommandBarWithFilter filter={this.state.workloadsFilter} filterToggled={workloadsFilterToggled} items={[]} />
-            </ConditionalChildren>
-            <ConditionalChildren renderChildren={this.state.selectedPivotKey === servicesPivotItemKey}>
-                <HeaderCommandBarWithFilter filter={this.state.svcFilter} filterToggled={servicesFilterToggled} items={[]} />
-            </ConditionalChildren>
+                <ConditionalChildren renderChildren={!this.state.selectedPivotKey || this.state.selectedPivotKey === workloadsPivotItemKey}>
+                    <HeaderCommandBarWithFilter filter={this.state.workloadsFilter} filterToggled={workloadsFilterToggled} items={[]} />
+                </ConditionalChildren>
+                <ConditionalChildren renderChildren={this.state.selectedPivotKey === servicesPivotItemKey}>
+                    <HeaderCommandBarWithFilter filter={this.state.svcFilter} filterToggled={servicesFilterToggled} items={[]} />
+                </ConditionalChildren>
             </>
         );
     }
@@ -412,7 +444,7 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
         KubeFactory.getImageLocation = this.props.getImageLocation || KubeFactory.getImageLocation;
     }
 
-    private _selectedItemViewMap: { [selectedItemKey: string]: (selectedItem: any) => JSX.Element | null } = {};
+    private _selectedItemViewMap: { [selectedItemKey: string]: (selectedItem: any, properties?: { [key: string]: any }) => JSX.Element | null } = {};
     private _objectFinder: { [selectedItemKey: string]: (name: string) => V1ReplicaSet | V1DaemonSet | V1StatefulSet | IServiceItem } = {};
     private _selectionStore: SelectionStore;
     private _workloadsActionCreator: WorkloadsActionsCreator;

--- a/src/WebUI/Common/KubeSummary.tsx
+++ b/src/WebUI/Common/KubeSummary.tsx
@@ -275,6 +275,18 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
         );
     }
 
+    private _getPodDetailsComponent(item: V1Pod, properties?: IPodDetailsSelectionPropeties): JSX.Element | null {
+        const selectionProperties = properties as IPodDetailsSelectionPropeties;
+        return selectionProperties ? (
+            <PodsDetails
+                pods={selectionProperties.pods}
+                parentKind={selectionProperties.parentItemKind}
+                parentName={selectionProperties.parentItemName}
+                onBackButtonClick={selectionProperties.onBackClick}
+                selectedPod={item} />)
+            : null;
+    }
+
     private _onSelectionStoreChanged = () => {
         const selectionStoreState = this._selectionStore.getState();
 
@@ -365,35 +377,7 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
         this._selectedItemViewMap[SelectedItemKeys.ServiceItemKey] = (service) => { return <ServiceDetails service={service} parentKind={service.kind || "Service"} />; };
         this._selectedItemViewMap[SelectedItemKeys.ImageDetailsKey] = (item) => { return <ImageDetails imageDetails={item} onBackButtonClick={this._setSelectionStateFalse} />; };
         this._selectedItemViewMap[SelectedItemKeys.OrphanPodKey] = (pod) => <PodsRightPanel key={pod.metadata.uid} pod={pod} podStatusProps={PodPhaseToStatus[pod.status.phase]} statusTooltip={pod.status.message || pod.status.phase} />;
-        this._selectedItemViewMap[SelectedItemKeys.ReplicaSetKey] = (item) => this._getWorkloadPodsViewComponent(item, "ReplicaSet", (item) => {
-            const status = (item as V1ReplicaSet).status;
-            return Utils.getPodsStatusProps(status.readyReplicas, status.replicas);
-        });
-
-        this._selectedItemViewMap[SelectedItemKeys.StatefulSetKey] = (item) => this._getWorkloadPodsViewComponent(item, "StatefulSet", (item) => {
-            const status = (item as V1StatefulSet).status;
-            return Utils.getPodsStatusProps(status.readyReplicas, status.replicas);
-        });
-
-        this._selectedItemViewMap[SelectedItemKeys.DaemonSetKey] = (item) => this._getWorkloadPodsViewComponent(item, "DaemonSet", (item) => {
-            const status = (item as V1DaemonSet).status;
-            return Utils.getPodsStatusProps(status.numberAvailable, status.desiredNumberScheduled);
-        });
-
-        this._selectedItemViewMap[SelectedItemKeys.ServiceItemKey] = (service) => { return <ServiceDetails service={service} parentKind={service.kind || "Service"} />; };
-        this._selectedItemViewMap[SelectedItemKeys.ImageDetailsKey] = (item) => { return <ImageDetails imageDetails={item} onBackButtonClick={this._setSelectionStateFalse} />; };
-        this._selectedItemViewMap[SelectedItemKeys.OrphanPodKey] = (pod) => <PodsRightPanel key={pod.metadata.uid} pod={pod} podStatusProps={PodPhaseToStatus[pod.status.phase]} statusTooltip={pod.status.message || pod.status.phase} />;
-        this._selectedItemViewMap[SelectedItemKeys.PodDetailsKey] = (item, properties?) => {
-            const selectionProperties = properties as IPodDetailsSelectionPropeties;
-            return selectionProperties ? (
-                <PodsDetails
-                    pods={selectionProperties.pods}
-                    parentKind={selectionProperties.parentItemKind}
-                    parentName={selectionProperties.parentItemName}
-                    onBackButtonClick={selectionProperties.onBackClick}
-                    selectedPod={item} />)
-                : null;
-        }
+        this._selectedItemViewMap[SelectedItemKeys.PodDetailsKey] = (item, properties?) => this._getPodDetailsComponent(item, properties as IPodDetailsSelectionPropeties);
     }
 
     private _setSelectionStateFalse = () => {

--- a/src/WebUI/Constants.ts
+++ b/src/WebUI/Constants.ts
@@ -6,7 +6,7 @@
 export const enum PodsRightPanelTabsKeys {
     PodsDetailsKey = "pod-details",
     PodsLogsKey = "pod-logs",
-    PodsYamlKey= "pod-yaml"
+    PodsYamlKey = "pod-yaml"
 }
 
 export const enum SelectedItemKeys {
@@ -15,7 +15,8 @@ export const enum SelectedItemKeys {
     StatefulSetKey = "stateful-set",
     OrphanPodKey = "orphan-pod",
     ServiceItemKey = "service-item",
-    ImageDetailsKey = "image-details"
+    ImageDetailsKey = "image-details",
+    PodDetailsKey = "pod-details"
 }
 
 export namespace WorkloadsEvents {

--- a/src/WebUI/RunDetails.scss
+++ b/src/WebUI/RunDetails.scss
@@ -1,3 +1,7 @@
 .runs-bullet {
     margin: 0 6px;
 }
+
+.run-name-link.bolt-table-link{
+    padding: 0;
+}

--- a/src/WebUI/RunDetails.tsx
+++ b/src/WebUI/RunDetails.tsx
@@ -20,7 +20,7 @@ export function getRunDetailsText(annotations: { [key: string]: string }, create
 
     const runElement = pipelineDetails.runName
         ? (pipelineDetails.runUrl
-            ? (<Link className={"run-name-link"} rel={"noopener noreferrer"} href={pipelineDetails.runUrl}> {"#" + pipelineDetails.runName} </Link>)
+            ? (<Link className={"run-name-link bolt-table-link"} rel={"noopener noreferrer"} href={pipelineDetails.runUrl}> {"#" + pipelineDetails.runName} </Link>)
             : "#" + pipelineDetails.runName)
         : undefined;
 

--- a/src/WebUI/Selection/SelectionActions.ts
+++ b/src/WebUI/Selection/SelectionActions.ts
@@ -13,6 +13,7 @@ export interface ISelectionPayload {
     itemUID: string;
     showSelectedItem: boolean;
     selectedItemType: string;
+    properties?: { [key: string]: any };
 }
 
 export class SelectionActions extends ActionsHubBase {

--- a/src/WebUI/Selection/SelectionStore.ts
+++ b/src/WebUI/Selection/SelectionStore.ts
@@ -15,6 +15,7 @@ export interface ISelectionStoreState {
     itemUID: string;
     showSelectedItem: boolean;
     selectedItemType: string;
+    properties?: { [key: string]: string };
 }
 
 export class SelectionStore extends StoreBase {
@@ -44,6 +45,7 @@ export class SelectionStore extends StoreBase {
         this._state.showSelectedItem = payload.showSelectedItem;
         this._state.selectedItemType = payload.selectedItemType;
         this._state.itemUID = payload.itemUID;
+        this._state.properties = payload.properties;
         this.emitChanged();
     }
 

--- a/src/WebUI/Types.d.ts
+++ b/src/WebUI/Types.d.ts
@@ -69,6 +69,13 @@ export interface ISetWorkloadTypeItem {
     status?: V1PodStatus;
 }
 
+export interface IPodDetailsSelectionPropeties {
+    pods: V1Pod[];
+    parentItemKind: string;
+    parentItemName: string;
+    onBackClick: () => void;
+}
+
 export interface IVssComponentProperties extends IBaseProps {
     /**
      * Components may specify a css classe list that should be applied to the primary

--- a/src/WebUI/WorkLoads/OtherWorkloadsTable.tsx
+++ b/src/WebUI/WorkLoads/OtherWorkloadsTable.tsx
@@ -243,12 +243,10 @@ export class OtherWorkloads extends BaseComponent<IOtherWorkloadsProperties, IOt
 
     private static _renderPodsCountCell(rowIndex: number, columnIndex: number, tableColumn: ITableColumn<ISetWorkloadTypeItem>, workload: ISetWorkloadTypeItem): JSX.Element {
         let { statusProps, pods, podsTooltip } = Utils.getPodsStatusProps(workload.currentPodCount, workload.desiredPodCount);
-        if (workload.kind === SelectedItemKeys.OrphanPodKey) {
-            statusProps = PodPhaseToStatus[workload.status.phase];
-            podsTooltip = workload.status.message || workload.status.phase
-        }
+        statusProps = PodPhaseToStatus[workload.status.phase];
+        podsTooltip = workload.status.message || workload.status.phase
 
-        return renderPodsStatusTableCell(rowIndex, columnIndex, tableColumn, pods, statusProps, podsTooltip);
+        return renderPodsStatusTableCell(rowIndex, columnIndex, tableColumn, pods, statusProps, undefined, podsTooltip);
     }
 
     private static _renderAgeCell(rowIndex: number, columnIndex: number, tableColumn: ITableColumn<ISetWorkloadTypeItem>, statefulSet: ISetWorkloadTypeItem): JSX.Element {

--- a/src/WebUI/WorkLoads/OtherWorkloadsTable.tsx
+++ b/src/WebUI/WorkLoads/OtherWorkloadsTable.tsx
@@ -12,14 +12,14 @@ import { ObservableValue } from "azure-devops-ui/Core/Observable";
 import { equals, format } from "azure-devops-ui/Core/Util/String";
 import { CustomHeader, HeaderTitle, HeaderTitleArea, HeaderTitleRow, TitleSize } from "azure-devops-ui/Header";
 import { Link } from "azure-devops-ui/Link";
-import { IStatusProps } from "azure-devops-ui/Status";
+import { Statuses } from "azure-devops-ui/Status";
 import { ITableColumn, Table, TwoLineTableCell } from "azure-devops-ui/Table";
 import { Tooltip } from "azure-devops-ui/TooltipEx";
 import { ArrayItemProvider } from "azure-devops-ui/Utilities/Provider";
 import * as React from "react";
 import { PodPhase, PodPhaseToStatus } from "../../Contracts/Contracts";
 import { KubeResourceType } from "../../Contracts/KubeServiceBase";
-import { defaultColumnRenderer, renderPodsStatusTableCell, renderTableCell } from "../Common/KubeCardWithTable";
+import { defaultColumnRenderer, renderPodsStatusTableCell, renderTableCell, onPodsColumnClicked } from "../Common/KubeCardWithTable";
 import { KubeSummary } from "../Common/KubeSummary";
 import { ImageDetailsEvents, SelectedItemKeys, WorkloadsEvents } from "../Constants";
 import { ActionsCreatorManager } from "../FluxCommon/ActionsCreatorManager";
@@ -191,7 +191,7 @@ export class OtherWorkloads extends BaseComponent<IOtherWorkloadsProperties, IOt
             id: podsKey,
             name: Resources.PodsText,
             width: new ObservableValue(140),
-            renderCell: OtherWorkloads._renderPodsCountCell
+            renderCell: this._renderPodsCountCell
         });
 
         columns.push({
@@ -241,12 +241,30 @@ export class OtherWorkloads extends BaseComponent<IOtherWorkloadsProperties, IOt
         return renderTableCell(rowIndex, columnIndex, tableColumn, itemToRender, undefined, "bolt-table-cell-content-with-link");
     }
 
-    private static _renderPodsCountCell(rowIndex: number, columnIndex: number, tableColumn: ITableColumn<ISetWorkloadTypeItem>, workload: ISetWorkloadTypeItem): JSX.Element {
+    private _renderPodsCountCell = (rowIndex: number, columnIndex: number, tableColumn: ITableColumn<ISetWorkloadTypeItem>, workload: ISetWorkloadTypeItem): JSX.Element => {
         let { statusProps, pods, podsTooltip } = Utils.getPodsStatusProps(workload.currentPodCount, workload.desiredPodCount);
-        statusProps = PodPhaseToStatus[workload.status.phase];
-        podsTooltip = workload.status.message || workload.status.phase
+        const payload = workload.payload;
+        const podslist = StoreManager.GetStore<PodsStore>(PodsStore).getState().podsList;
+        const relevantPods = (podslist && podslist.items && podslist.items.filter(p => (payload && Utils.isOwnerMatched(p.metadata, payload.metadata.uid)) || false))
 
-        return renderPodsStatusTableCell(rowIndex, columnIndex, tableColumn, pods, statusProps, undefined, podsTooltip);
+        let type = "";
+        switch (payload.kind) {
+            case SelectedItemKeys.DaemonSetKey:
+                type = "DaemonSet";
+                break;
+            case SelectedItemKeys.ReplicaSetKey:
+                type = "ReplicaSet";
+                break;
+            case SelectedItemKeys.StatefulSetKey:
+                type = "StatefulSet";
+                break;
+            case SelectedItemKeys.OrphanPodKey:
+                type = "Pod";
+                break;
+        }
+        const _onPodsClicked = (relevantPods && payload) ? (() => onPodsColumnClicked(relevantPods, payload, type, this._selectionActionCreator)) : undefined;
+
+        return renderPodsStatusTableCell(rowIndex, columnIndex, tableColumn, pods, statusProps, podsTooltip, _onPodsClicked);
     }
 
     private static _renderAgeCell(rowIndex: number, columnIndex: number, tableColumn: ITableColumn<ISetWorkloadTypeItem>, statefulSet: ISetWorkloadTypeItem): JSX.Element {


### PR DESCRIPTION
Render the pods column in deployments table as a link
The link takes the user to the pod details view

The change in OtherWorkloadsTable.tsx is in response to a comment in https://github.com/Microsoft/azpipelines-kubernetesUI/pull/115