### PR TITLE
Add a telemetry service as a prop in kubesummary, and not just markTTI

### DIFF
--- a/src/Contracts/Contracts.ts
+++ b/src/Contracts/Contracts.ts
@@ -33,6 +33,12 @@ export interface IImageService {
     getImageDetails(imageName: string): Promise<IImageDetails | undefined>;
 }
 
+export interface ITelemetryService {
+    onClickTelemetry(source: string, additionalProperties?: { [key: string]: any }): void;
+    scenarioStart(scenarioName: string, additionalProperties?: { [key: string]: any }): void;
+    scenarioEnd(scenarioName: string, additionalProperties?: { [key: string]: any }): void;
+}
+
 /**
  * https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
  **/

--- a/src/WebUI/Common/KubeSummary.tsx
+++ b/src/WebUI/Common/KubeSummary.tsx
@@ -18,14 +18,14 @@ import { Filter, FILTER_CHANGE_EVENT, IFilterState } from "azure-devops-ui/Utili
 import { Action, createBrowserHistory, History, Location, UnregisterCallback } from "history";
 import * as queryString from "query-string";
 import * as React from "react";
-import { IImageService, IKubeService, KubeImage } from "../../Contracts/Contracts";
+import { IImageService, IKubeService, KubeImage, PodPhaseToStatus, ITelemetryService } from "../../Contracts/Contracts";
 import { IImageDetails } from "../../Contracts/Types";
 import { SelectedItemKeys, ServicesEvents, WorkloadsEvents } from "../Constants";
 import { ActionsCreatorManager } from "../FluxCommon/ActionsCreatorManager";
 import { StoreManager } from "../FluxCommon/StoreManager";
 import { ImageDetails } from "../ImageDetails/ImageDetails";
-import { KubeFactory } from "../KubeFactory";
 import { PodsDetails } from "../Pods/PodsDetails";
+import { KubeFactory, DefaultTelemetryService } from "../KubeFactory";
 import { PodsRightPanel } from "../Pods/PodsRightPanel";
 import * as Resources from "../Resources";
 import { SelectionActionsCreator } from "../Selection/SelectionActionCreator";
@@ -68,7 +68,7 @@ export interface IKubeSummaryProps extends IVssComponentProperties {
     imageService?: IImageService;
     namespace?: string;
     clusterName?: string;
-    markTTI?: () => void;
+    telemteryService?: ITelemetryService;
     getImageLocation?: (image: KubeImage) => string | undefined;
 }
 
@@ -427,6 +427,7 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
     }
 
     private _initializeFactorySettings(): void {
+        KubeFactory.telemetryService = this.props.telemteryService || new DefaultTelemetryService();
         KubeFactory.markTTI = this.props.markTTI || KubeFactory.markTTI;
         KubeFactory.getImageLocation = this.props.getImageLocation || KubeFactory.getImageLocation;
     }

--- a/src/WebUI/Common/KubeSummary.tsx
+++ b/src/WebUI/Common/KubeSummary.tsx
@@ -18,7 +18,7 @@ import { Filter, FILTER_CHANGE_EVENT, IFilterState } from "azure-devops-ui/Utili
 import { Action, createBrowserHistory, History, Location, UnregisterCallback } from "history";
 import * as queryString from "query-string";
 import * as React from "react";
-import { IImageService, IKubeService, KubeImage, PodPhaseToStatus, ITelemetryService } from "../../Contracts/Contracts";
+import { IImageService, IKubeService, KubeImage, ITelemetryService } from "../../Contracts/Contracts";
 import { IImageDetails } from "../../Contracts/Types";
 import { SelectedItemKeys, ServicesEvents, WorkloadsEvents } from "../Constants";
 import { ActionsCreatorManager } from "../FluxCommon/ActionsCreatorManager";

--- a/src/WebUI/Constants.ts
+++ b/src/WebUI/Constants.ts
@@ -48,3 +48,8 @@ export namespace HyperLinks {
     export const LinkToPodsUsingLabelsLink: string = "https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/";
     export const ServicesLink: string = "https://go.microsoft.com/fwlink/?linkid=2083858";
 }
+
+export namespace Scenarios{
+    const Prefix = "KubeSummary.";
+    export const Deployments = Prefix + "Deployments";
+}

--- a/src/WebUI/KubeFactory.ts
+++ b/src/WebUI/KubeFactory.ts
@@ -1,4 +1,4 @@
-import { KubeImage } from "../Contracts/Contracts";
+import { KubeImage, ITelemetryService } from "../Contracts/Contracts";
 
 export class KubeFactory {
     public static getImageLocation = (image: KubeImage): string | undefined => {
@@ -9,9 +9,28 @@ export class KubeFactory {
         // Default implementation: Do nothing
     }
 
+    public static telemetryService: ITelemetryService;
+
     private static _imageLocations: Map<KubeImage, string> = new Map([
         [KubeImage.zeroData, require("../img/zero-data.svg")],
         [KubeImage.zeroResults, require("../img/zero-results.svg")],
         [KubeImage.zeroWorkloads, require("../img/zero-workloads.svg")]
     ]);
+}
+
+export class DefaultTelemetryService implements ITelemetryService {
+    public onClickTelemetry(source: string, additionalProperties?: { [key: string]: any; }): void {
+        console.log("Item clicked " + source);
+        console.log(additionalProperties);
+    }
+
+    scenarioStart(scenarioName: string, additionalProperties?: { [key: string]: any; }): void {
+        console.log("Scenario started " + scenarioName);
+        console.log(additionalProperties);
+    }
+
+    scenarioEnd(scenarioName: string, additionalProperties?: { [key: string]: any; }): void {
+        console.log("Scenario completed " + scenarioName);
+        console.log(additionalProperties);
+    }
 }

--- a/src/WebUI/WorkLoads/DeploymentsTable.tsx
+++ b/src/WebUI/WorkLoads/DeploymentsTable.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 import { defaultColumnRenderer, onPodsColumnClicked, renderPodsStatusTableCell, renderTableCell } from "../Common/KubeCardWithTable";
 import { KubeSummary } from "../Common/KubeSummary";
 import { Tags } from "../Common/Tags";
-import { ImageDetailsEvents, SelectedItemKeys, WorkloadsEvents } from "../Constants";
+import { ImageDetailsEvents, SelectedItemKeys, WorkloadsEvents, Scenarios } from "../Constants";
 import { ActionsCreatorManager } from "../FluxCommon/ActionsCreatorManager";
 import { StoreManager } from "../FluxCommon/StoreManager";
 import { ImageDetailsStore } from "../ImageDetails/ImageDetailsStore";
@@ -47,6 +47,7 @@ export class DeploymentsTable extends BaseComponent<IDeploymentsTableProperties,
     constructor(props: IDeploymentsTableProperties) {
         super(props, {});
 
+        KubeFactory.telemetryService.scenarioStart(Scenarios.Deployments);
         this._workloadsActionCreator = ActionsCreatorManager.GetActionCreator<WorkloadsActionsCreator>(WorkloadsActionsCreator);
         this._selectionActionCreator = ActionsCreatorManager.GetActionCreator<SelectionActionsCreator>(SelectionActionsCreator);
         this._imageDetailsStore = StoreManager.GetStore<ImageDetailsStore>(ImageDetailsStore);
@@ -330,13 +331,18 @@ export class DeploymentsTable extends BaseComponent<IDeploymentsTableProperties,
     }
 
     private _markTTI(prevProps: IDeploymentsTableProperties, prevState: IDeploymentsTableState): void {
-        if (!this._isTTIMarked) {
-            // if previously replicaSet did not exist and is rendered just now
-            const prevReplicas = prevState.replicaSetList;
-            const currentReplicas = this.state.replicaSetList;
-            if ((!prevReplicas || !prevReplicas.items) && (currentReplicas && currentReplicas.items)) {
+        const prevReplicas = prevState.replicaSetList;
+        const currentReplicas = this.state.replicaSetList;
+        if ((!prevReplicas || !prevReplicas.items) && (currentReplicas && currentReplicas.items)) {
+            if (!this._isTTIMarked) {
+                // if previously replicaSet did not exist and is rendered just now
+                KubeFactory.telemetryService.scenarioEnd(Scenarios.Deployments, { isTTI: true })
+
                 KubeFactory.markTTI();
                 this._isTTIMarked = true;
+            }
+            else {
+                KubeFactory.telemetryService.scenarioEnd(Scenarios.Deployments);
             }
         }
     }


### PR DESCRIPTION
This is the first PR for adding the ability to publish telemetry.

Remove markTTI from the props, but still handling it, for compat. I'll add code for publishing more telemetry from the code