### PR TITLE
Fill the correct annotation key for job name

### DIFF
--- a/src/WebUI/Utils.ts
+++ b/src/WebUI/Utils.ts
@@ -15,7 +15,7 @@ import * as Resources from "./Resources";
 const pipelineNameAnnotationKey: string = "azure-pipelines/pipeline";
 const pipelineRunIdAnnotationKey: string = "azure-pipelines/execution";
 const pipelineRunUrlAnnotationKey: string = "azure-pipelines/executionuri";
-const pipelineJobNameAnnotationKey: string = "azure-pipelines/__TEMP_PLACEHOLDER__";
+const pipelineJobNameAnnotationKey: string = "azure-pipelines/jobName";
 const matchPatternForImageName = new RegExp(/\:\/\/(.+?)\@/);
 const matchPatternForDigest = new RegExp(/\@sha256\:(.+)/);
 const invalidCharPatternInNamespace = new RegExp(/[:.]/);


### PR DESCRIPTION
Previously, we weren't aware of the key that will contain the job name of the deploying image
Replacing the placeholder we had with the correct value

Refer to https://github.com/Microsoft/azure-pipelines-tasks/pull/9992/files#diff-57e62668f44b350039fdcaa85d3eabd0