### PR TITLE
Fix type value sent to pod details on click

### DIFF
--- a/src/WebUI/Common/KubeCardWithTable.tsx
+++ b/src/WebUI/Common/KubeCardWithTable.tsx
@@ -248,7 +248,12 @@ export function renderPodsStatusTableCell(
     return renderTableCell(rowIndex, columnIndex, tableColumn, itemToRender, undefined, podsCountString ? "bolt-table-cell-content-with-link" : "");
 }
 
-export function onPodsColumnClicked(pods: V1Pod[], item: V1ReplicaSet | V1StatefulSet | V1DaemonSet | V1Pod, itemKind: string, selectionActionCreator: SelectionActionsCreator): void {
+export function onPodsColumnClicked(
+    pods: V1Pod[],
+    item: V1ReplicaSet | V1StatefulSet | V1DaemonSet | V1Pod,
+    itemKind: string,
+    itemTypeKey: SelectedItemKeys,
+    selectionActionCreator: SelectionActionsCreator): void {
     const selectedPod = pods.find(p => Utils.generatePodStatusProps(p.status).statusProps === Statuses.Failed) || pods[0];
 
     // Item kind "Pod" implies that the type is an orphan pod
@@ -256,7 +261,7 @@ export function onPodsColumnClicked(pods: V1Pod[], item: V1ReplicaSet | V1Statef
         pods: pods,
         parentItemKind: itemKind,
         parentItemName: item.metadata.name,
-        onBackClick: () => { item && selectionActionCreator.selectItem({ item: item, itemUID: item.metadata.uid, selectedItemType: SelectedItemKeys.ReplicaSetKey, showSelectedItem: true }) }
+        onBackClick: () => { item && selectionActionCreator.selectItem({ item: item, itemUID: item.metadata.uid, selectedItemType: itemTypeKey, showSelectedItem: true }) }
     } as IPodDetailsSelectionProperties;
 
     selectionActionCreator.selectItem({

--- a/src/WebUI/Common/KubeSummary.tsx
+++ b/src/WebUI/Common/KubeSummary.tsx
@@ -43,6 +43,7 @@ import { WorkloadsPivot } from "../Workloads/WorkloadsPivot";
 import { WorkloadsStore } from "../Workloads/WorkloadsStore";
 import "./KubeSummary.scss";
 import { KubeZeroData } from "./KubeZeroData";
+import { PodsStore } from "../Pods/PodsStore";
 
 const workloadsPivotItemKey: string = "workloads";
 const servicesPivotItemKey: string = "services";
@@ -106,6 +107,7 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
         this._selectionStore = StoreManager.GetStore<SelectionStore>(SelectionStore);
         // ensure workload store is created before get Deployments action
         this._workloadsStore = StoreManager.GetStore<WorkloadsStore>(WorkloadsStore);
+        this._podsStore = StoreManager.GetStore<PodsStore>(PodsStore);
 
         this._workloadsActionCreator = ActionsCreatorManager.GetActionCreator<WorkloadsActionsCreator>(WorkloadsActionsCreator);
         this._selectionActionCreator = ActionsCreatorManager.GetActionCreator<SelectionActionsCreator>(SelectionActionsCreator);
@@ -412,15 +414,15 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
         this._objectFinder[SelectedItemKeys.ReplicaSetKey] = (uid) => KubeSummary._getFilteredFirstObject(this._workloadsStore.getState().replicaSetList, uid);
         this._objectFinder[SelectedItemKeys.StatefulSetKey] = (uid) => KubeSummary._getFilteredFirstObject(this._workloadsStore.getState().statefulSetList, uid);
         this._objectFinder[SelectedItemKeys.DaemonSetKey] = (uid) => KubeSummary._getFilteredFirstObject(this._workloadsStore.getState().daemonSetList, uid);
+        this._objectFinder[SelectedItemKeys.PodDetailsKey] = (uid) => KubeSummary._getFilteredFirstObject(this._podsStore.getState().podsList, uid);
         this._objectFinder[SelectedItemKeys.ServiceItemKey] = (uid) => {
             const filteredServices = KubeSummary._getFilteredFirstObject(this._servicesStore.getState().serviceList, uid);
             return ServicesTable.getServiceItems(filteredServices)[0];
         };
     }
 
-    private static _getFilteredFirstObject(itemList: any, uid: string): any {
-        itemList = (itemList || {}) as any;
-        const filteredItems = (itemList.items || []).filter(r => r.metadata.uid === uid);
+    private static _getFilteredFirstObject(itemList: { items?: { metadata: V1ObjectMeta }[] } | undefined, uid: string): any {
+        const filteredItems = ((itemList || {}).items || []).filter(r => r.metadata.uid === uid);
         return filteredItems && filteredItems.length > 0 ? filteredItems[0] : undefined
     }
 
@@ -452,6 +454,7 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
     private _selectionStore: SelectionStore;
     private _workloadsActionCreator: WorkloadsActionsCreator;
     private _workloadsStore: WorkloadsStore;
+    private _podsStore: PodsStore
     private _servicesStore: ServicesStore;
     private _historyService: History;
     private _historyUnlisten: UnregisterCallback;

--- a/src/WebUI/WorkLoads/DeploymentsTable.tsx
+++ b/src/WebUI/WorkLoads/DeploymentsTable.tsx
@@ -260,7 +260,7 @@ export class DeploymentsTable extends BaseComponent<IDeploymentsTableProperties,
         const podslist = StoreManager.GetStore<PodsStore>(PodsStore).getState().podsList;
         const relevantPods = (podslist && podslist.items && podslist.items.filter(p => (replicaSet && Utils.isOwnerMatched(p.metadata, replicaSet.metadata.uid)) || false))
 
-        const _onPodsClicked = (relevantPods && replicaSet) ? (() => onPodsColumnClicked(relevantPods, replicaSet, "ReplicaSet", this._selectionActionCreator)) : undefined;
+        const _onPodsClicked = (relevantPods && replicaSet) ? (() => onPodsColumnClicked(relevantPods, replicaSet, "ReplicaSet", SelectedItemKeys.ReplicaSetKey, this._selectionActionCreator)) : undefined;
 
         return renderPodsStatusTableCell(rowIndex, columnIndex, tableColumn, deployment.pods, deployment.statusProps, deployment.podsTooltip, _onPodsClicked);
     }

--- a/src/WebUI/WorkLoads/OtherWorkloadsTable.tsx
+++ b/src/WebUI/WorkLoads/OtherWorkloadsTable.tsx
@@ -247,7 +247,7 @@ export class OtherWorkloads extends BaseComponent<IOtherWorkloadsProperties, IOt
         const relevantPods = (podslist && podslist.items && podslist.items.filter(p => (payload && Utils.isOwnerMatched(p.metadata, payload.metadata.uid)) || false))
 
         let type = "";
-        switch (payload.kind) {
+        switch (workload.kind) {
             case SelectedItemKeys.DaemonSetKey:
                 type = "DaemonSet";
                 break;
@@ -261,7 +261,7 @@ export class OtherWorkloads extends BaseComponent<IOtherWorkloadsProperties, IOt
                 type = "Pod";
                 break;
         }
-        const _onPodsClicked = (relevantPods && payload) ? (() => onPodsColumnClicked(relevantPods, payload, type, this._selectionActionCreator)) : undefined;
+        const _onPodsClicked = (relevantPods && payload) ? (() => onPodsColumnClicked(relevantPods, payload, type, workload.kind as SelectedItemKeys, this._selectionActionCreator)) : undefined;
 
         return renderPodsStatusTableCell(rowIndex, columnIndex, tableColumn, pods, statusProps, podsTooltip, _onPodsClicked);
     }


### PR DESCRIPTION
We were erroneously sending the wrong type to pods details. 

Also add pod details view to the list of views that can be reached through history. Currently implementation is missing. Needs to be added