### PR TITLE
make yaml reader as an interface

### DIFF
--- a/src/WebUI/Common/ContentReader.tsx
+++ b/src/WebUI/Common/ContentReader.tsx
@@ -1,0 +1,75 @@
+/*
+    Copyright (c) Microsoft Corporation. All rights reserved.
+    Licensed under the MIT license.
+*/
+
+import * as React from "react";
+
+// basic editor functionality
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
+// languages supported in editor
+import "monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution";
+// additional functionality of editor
+import "monaco-editor/esm/vs/editor/browser/controller/coreCommands";
+import "monaco-editor/esm/vs/editor/contrib/find/findController";
+import "monaco-editor/esm/vs/editor/contrib/message/messageController";
+
+export interface IReaderProps {
+    text: string;
+    options?: monaco.editor.IEditorConstructionOptions;
+}
+
+export class ContentReader extends React.Component<IReaderProps> {
+    public render(): JSX.Element {
+        return (
+            <div
+                id="k8s-monaco-reader"
+                className="reader-inner flex-row flex-center absolute-fill"
+                ref={this._createEditor}
+            />
+        );
+    }
+
+    public componentDidMount(): void {
+        window.addEventListener("resize", this._onResizeHandler);
+    }
+
+    public componentWillUnmount(): void {
+        window.removeEventListener("resize", this._onResizeHandler);
+        this._disposeEditor();
+    }
+
+    private _onResizeHandler = () => {
+        if (this._editor) {
+            this._editor.layout();
+        }
+    }
+
+    private _createEditor = (innerRef) => {
+        if (innerRef) {
+            const text = this.props.text || "";
+            this._disposeEditor();
+
+            this._editor = monaco.editor.create(innerRef, {
+                readOnly: true,
+                renderWhitespace: "all",
+                scrollbar: { horizontalScrollbarSize: 16 },
+                lineNumbers: "on",
+                extraEditorClassName: "k8s-monaco-editor",
+                theme: "vs",
+                language: "yaml",
+                ...this.props.options,
+                value: text
+            });
+        }
+    }
+
+    private _disposeEditor(): void {
+        if (this._editor) {
+            this._editor.dispose();
+            this._editor = undefined;
+        }
+    }
+
+    private _editor: monaco.editor.IStandaloneCodeEditor | undefined;
+}

--- a/src/WebUI/Common/KubeConsumer.ts
+++ b/src/WebUI/Common/KubeConsumer.ts
@@ -1,0 +1,30 @@
+/*
+    Copyright (c) Microsoft Corporation. All rights reserved.
+    Licensed under the MIT license.
+*/
+
+class KubeConsumer {
+    public static setReaderComponent(reader?: (props?: any) => React.ReactNode): void {
+        if (reader) {
+            KubeConsumer._readerComponentFunc = reader;
+        }
+    }
+
+    public static getReaderComponent(props?: any): React.ReactNode {
+        if (KubeConsumer._readerComponentFunc) {
+            return KubeConsumer._readerComponentFunc(props);
+        }
+
+        return null;
+    }
+
+    private static _readerComponentFunc?: (props?: any) => React.ReactNode;
+}
+
+export function getContentReaderComponent(props?: any): React.ReactNode {
+    return KubeConsumer.getReaderComponent(props);
+}
+
+export function setContentReaderComponent(reader?: (props?: any) => React.ReactNode): void {
+    KubeConsumer.setReaderComponent(reader);
+}

--- a/src/WebUI/Common/KubeSummary.tsx
+++ b/src/WebUI/Common/KubeSummary.tsx
@@ -44,6 +44,7 @@ import { WorkloadsStore } from "../Workloads/WorkloadsStore";
 import "./KubeSummary.scss";
 import { KubeZeroData } from "./KubeZeroData";
 import { PodsStore } from "../Pods/PodsStore";
+import { setContentReaderComponent } from "./KubeConsumer";
 
 const workloadsPivotItemKey: string = "workloads";
 const servicesPivotItemKey: string = "services";
@@ -71,6 +72,9 @@ export interface IKubeSummaryProps extends IVssComponentProperties {
     clusterName?: string;
     telemteryService?: ITelemetryService;
     getImageLocation?: (image: KubeImage) => string | undefined;
+    // props has text and reader options.
+    // reader options are of type monaco.editor.IEditorConstructionOptions
+    getContentReaderComponent?: (props?: any) => React.ReactNode;
 }
 
 export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesContainerState> {
@@ -78,6 +82,7 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
         super(props, {});
         KubeSummary._imageService = this.props.imageService;
         KubeSummary._kubeservice = this.props.kubeService;
+        setContentReaderComponent(this.props.getContentReaderComponent);
 
         this._initializeFactorySettings();
         const workloadsFilter = new Filter();

--- a/src/WebUI/Pods/PodContentReader.tsx
+++ b/src/WebUI/Pods/PodContentReader.tsx
@@ -4,84 +4,29 @@
 */
 
 import { BaseComponent } from "@uifabric/utilities";
-import { css } from "azure-devops-ui/Util";
 import { CardContent, CustomCard } from "azure-devops-ui/Card";
+import { css } from "azure-devops-ui/Util";
 import * as React from "react";
+import { getContentReaderComponent } from "../Common/KubeConsumer";
 import { IVssComponentProperties } from "../Types";
 
-// basic editor functionality
-import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
-// languages supported in editor
-import "monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution";
-// additional functionality of editor
-import "monaco-editor/esm/vs/editor/browser/controller/coreCommands";
-import "monaco-editor/esm/vs/editor/contrib/find/findController";
-import "monaco-editor/esm/vs/editor/contrib/message/messageController";
-
-export interface IReaderProps extends IVssComponentProperties {
+export interface IPodReaderProps extends IVssComponentProperties {
     text: string;
-    options?: monaco.editor.IEditorConstructionOptions;
+    options?: any; /* monaco.editor.IEditorConstructionOptions */
     contentClassName?: string;
 }
 
-export class PodContentReader extends BaseComponent<IReaderProps> {
+export class PodContentReader extends BaseComponent<IPodReaderProps> {
     public render(): JSX.Element {
         return (
             // monaco-editor class added here to have the same theme as monaco.
             <CustomCard className={css(this.props.className || "", "monaco-editor", "k8s-card-padding", "flex-grow")}>
                 <CardContent className={css(this.props.contentClassName || "", "reader-content")} contentPadding={false}>
                     <div className="reader-outer" style={{ width: "100%", height: "500px", position: "relative" }}>
-                        <div
-                            id="k8s-monaco-reader"
-                            className="reader-inner flex-row flex-center absolute-fill"
-                            ref={this._createEditor}
-                        />
+                        {getContentReaderComponent({ ...this.props })}
                     </div>
                 </CardContent>
             </CustomCard>
         );
     }
-
-    public componentDidMount(): void {
-        window.addEventListener("resize", this._onResizeHandler);
-    }
-
-    public componentWillUnmount(): void {
-        window.removeEventListener("resize", this._onResizeHandler);
-        this._disposeEditor();
-    }
-
-    private _onResizeHandler = () => {
-        if (this._editor) {
-            this._editor.layout();
-        }
-    }
-
-    private _createEditor = (innerRef) => {
-        if (innerRef) {
-            const text = this.props.text || "";
-            this._disposeEditor();
-
-            this._editor = monaco.editor.create(innerRef, {
-                readOnly: true,
-                renderWhitespace: "all",
-                scrollbar: { horizontalScrollbarSize: 16 },
-                lineNumbers: "on",
-                extraEditorClassName: "k8s-monaco-editor",
-                theme: "vs",
-                language: "yaml",
-                ...this.props.options,
-                value: text
-            });
-        }
-    }
-
-    private _disposeEditor(): void {
-        if (this._editor) {
-            this._editor.dispose();
-            this._editor = undefined;
-        }
-    }
-
-    private _editor: monaco.editor.IStandaloneCodeEditor | undefined;
 }


### PR DESCRIPTION
We had to make this change to consume package in DevOps, so that monaco-editor is used from the DevOps directly rather from this package.

In WebApp repo, i have used the ContentReader from this repo and i could see UI for YAML/Logs. please note this is a breaking change, even though we have made the props as options.
`getContentReaderComponent: (props?: any) => <ContentReader {...props} />`

![image](https://user-images.githubusercontent.com/26214977/55635327-09c87880-57de-11e9-9a49-8d4da69988e4.png)

Similar change has to be done for DevOps, i have tested in DevOps, by not having the monaco-editor and ContentReader in this repo, and prop getContentReaderComponent defined in DevOps [working example].
`getContentReaderComponent: (props?: any) => <div>{"New reader"}</div>`

![image](https://user-images.githubusercontent.com/26214977/55635194-c110bf80-57dd-11e9-8c2d-29804ce8464a.png)
