### PR TITLE
Make pod details work from url only.

### DIFF
--- a/src/WebUI/Common/KubeCardWithTable.tsx
+++ b/src/WebUI/Common/KubeCardWithTable.tsx
@@ -253,16 +253,12 @@ export function onPodsColumnClicked(
     pods: V1Pod[],
     item: V1ReplicaSet | V1StatefulSet | V1DaemonSet | V1Pod,
     itemKind: string,
-    itemTypeKey: SelectedItemKeys,
     selectionActionCreator: SelectionActionsCreator): void {
     const selectedPod = pods.find(p => Utils.generatePodStatusProps(p.status).statusProps === Statuses.Failed) || pods[0];
 
     // Item kind "Pod" implies that the type is an orphan pod
     const properties = itemKind === "Pod" ? undefined : {
-        pods: pods,
-        parentItemKind: itemKind,
-        parentItemName: item.metadata.name,
-        onBackClick: () => { item && selectionActionCreator.selectItem({ item: item, itemUID: item.metadata.uid, selectedItemType: itemTypeKey, showSelectedItem: true }) }
+        parentUid: item.metadata.uid
     } as IPodDetailsSelectionProperties;
 
     selectionActionCreator.selectItem({

--- a/src/WebUI/Common/KubeSummary.tsx
+++ b/src/WebUI/Common/KubeSummary.tsx
@@ -34,7 +34,6 @@ import { SelectionStore } from "../Selection/SelectionStore";
 import { ServiceDetails } from "../Services/ServiceDetails";
 import { ServicesPivot } from "../Services/ServicesPivot";
 import { ServicesStore } from "../Services/ServicesStore";
-import { ServicesTable } from "../Services/ServicesTable";
 import { IPodDetailsSelectionProperties, IServiceItem, IVssComponentProperties } from "../Types";
 import { Utils } from "../Utils";
 import { WorkloadDetails } from "../Workloads/WorkloadDetails";
@@ -58,7 +57,8 @@ export interface IKubernetesContainerState {
     selectedItem?: V1ReplicaSet | V1DaemonSet | V1StatefulSet | V1Pod | IServiceItem | IImageDetails;
     showSelectedItem?: boolean;
     selectedItemType?: string;
-    selectedItemProperties?: { [key: string]: string };
+    selectedItemUid?: string;
+    selectedItemProperties?: { [key: string]: any };
     resourceSize: number;
     workloadsFilter: Filter;
     svcFilter: Filter;
@@ -104,6 +104,8 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
             namespace: this.props.namespace || "",
             selectedPivotKey: selectedPivot,
             showSelectedItem: queryParams.uid ? true : false,
+            selectedItemUid: queryParams.uid as string,
+            selectedItemProperties: queryParams as { [key: string]: any },
             selectedItem: undefined,
             selectedItemType: queryParams.type as string || "",
             resourceSize: 0,
@@ -174,10 +176,10 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
             const typeName: string = routeValues["type"] as string;
             const objectId: string = routeValues["uid"] as string;
             const selectedItem = this._objectFinder[typeName](objectId);
-            this.setState({ selectedItemType: typeName, selectedItem: selectedItem, showSelectedItem: true });
+            this.setState({ selectedItemType: typeName, selectedItem: selectedItem, showSelectedItem: true, selectedItemUid: objectId, selectedItemProperties: routeValues });
         }
         else {
-            this.setState({ selectedItemType: "", selectedItem: undefined, showSelectedItem: false });
+            this.setState({ selectedItemType: "", selectedItem: undefined, showSelectedItem: false, selectedItemUid: undefined });
         }
     }
 
@@ -260,12 +262,12 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
     private _getSelectedItemPodsView(): JSX.Element | null {
         const selectedItem = this.state.selectedItem;
         const selectedItemType = this.state.selectedItemType;
-        const isEmptyItemAllowed = ![SelectedItemKeys.OrphanPodKey, SelectedItemKeys.PodDetailsKey].some(s => s === selectedItemType);
+        const isEmptyItemAllowed = ![SelectedItemKeys.OrphanPodKey].some(s => s === selectedItemType);
         // ToDo :: Currently for imageDetails type, the selected item will be undefined, hence adding below check. Remove this once we have data from imageService
         if (selectedItemType
             && (selectedItem || isEmptyItemAllowed)
             && this._selectedItemViewMap.hasOwnProperty(selectedItemType)) {
-            return this._selectedItemViewMap[selectedItemType](selectedItem, this.state.selectedItemProperties);
+            return this._selectedItemViewMap[selectedItemType](selectedItem, this.state.selectedItemUid, this.state.selectedItemProperties);
         }
 
         return null;
@@ -287,15 +289,14 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
         );
     }
 
-    private _getPodDetailsComponent(item: V1Pod, properties?: IPodDetailsSelectionProperties): JSX.Element | null {
+    private _getPodDetailsComponent(podUid?: string, properties?: IPodDetailsSelectionProperties): JSX.Element | null {
         const selectionProperties = properties as IPodDetailsSelectionProperties;
         return selectionProperties ? (
             <PodsDetails
-                pods={selectionProperties.pods}
-                parentKind={selectionProperties.parentItemKind}
-                parentName={selectionProperties.parentItemName}
-                onBackButtonClick={selectionProperties.onBackClick}
-                selectedPod={item} />)
+                parentUid={selectionProperties.parentUid}
+                serviceName={selectionProperties.serviceName}
+                serviceSelector={selectionProperties.serviceSelector}
+                selectedPodUid={podUid} />)
             : null;
     }
 
@@ -319,6 +320,7 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
                 showSelectedItem: selectionStoreState.showSelectedItem,
                 selectedItem: item,
                 selectedItemType: selectionStoreState.selectedItemType,
+                selectedItemUid: selectionStoreState.itemUID,
                 selectedItemProperties: selectionStoreState.properties
             });
         }
@@ -339,28 +341,32 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
                     if (replicaSets) {
                         item = getMatchingItem(replicaSets.items);
                     }
-                    invokedFunc = () => KubeSummary.getKubeService().getReplicaSets();
+                    if (!item) {
+                        invokedFunc = () => KubeSummary.getKubeService().getReplicaSets();
+                    }
                     break;
                 case SelectedItemKeys.StatefulSetKey:
                     const statefulSets = this._workloadsStore.getState().statefulSetList;
                     if (statefulSets) {
                         item = getMatchingItem(statefulSets.items);
                     }
-                    invokedFunc = () => KubeSummary.getKubeService().getStatefulSets();
+                    if (!item) {
+                        invokedFunc = () => KubeSummary.getKubeService().getStatefulSets();
+                    }
                     break;
                 case SelectedItemKeys.DaemonSetKey:
                     const daemonSets = this._workloadsStore.getState().daemonSetList;
                     if (daemonSets) {
                         item = getMatchingItem(daemonSets.items);
                     }
-                    invokedFunc = () => KubeSummary.getKubeService().getDaemonSets();
+
+                    if (!item) {
+                        invokedFunc = () => KubeSummary.getKubeService().getDaemonSets();
+                    }
                     break;
             }
 
-            if (item) {
-                setStateWithSelection(item);
-            }
-            else if (invokedFunc) {
+            if (invokedFunc) {
                 invokedFunc().then(list => {
                     // If the selection has been modified while this promise was being resolved, don't do anything
                     if (selectionStoreState.itemUID !== this._selectionStore.getState().itemUID) {
@@ -375,6 +381,9 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
                         setStateWithSelection(item);
                     }
                 });
+            }
+            else {
+                setStateWithSelection(item);
             }
         }
         else {
@@ -417,7 +426,7 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
 
         this._selectedItemViewMap[SelectedItemKeys.ServiceItemKey] = (service) => { return <ServiceDetails service={service} parentKind={(service && service.kind) || "Service"} />; };
         this._selectedItemViewMap[SelectedItemKeys.ImageDetailsKey] = (item) => { return <ImageDetails imageDetails={item} onBackButtonClick={this._setSelectionStateFalse} />; };
-        this._selectedItemViewMap[SelectedItemKeys.PodDetailsKey] = (item, properties?) => this._getPodDetailsComponent(item, properties as IPodDetailsSelectionProperties);
+        this._selectedItemViewMap[SelectedItemKeys.PodDetailsKey] = (item, uid, properties?) => this._getPodDetailsComponent(uid, properties as IPodDetailsSelectionProperties);
     }
 
     private _setSelectionStateFalse = () => {
@@ -436,8 +445,8 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
         this._objectFinder[SelectedItemKeys.DaemonSetKey] = (uid) => KubeSummary._getFilteredFirstObject(this._workloadsStore.getState().daemonSetList, uid);
         this._objectFinder[SelectedItemKeys.PodDetailsKey] = (uid) => KubeSummary._getFilteredFirstObject(this._podsStore.getState().podsList, uid);
         this._objectFinder[SelectedItemKeys.ServiceItemKey] = (uid) => {
-            const filteredServices = KubeSummary._getFilteredFirstObject(this._servicesStore.getState().serviceList, uid);
-            return filteredServices ? getServiceItems(filteredServices)[0] : undefined;
+            const filteredService = KubeSummary._getFilteredFirstObject(this._servicesStore.getState().serviceList, uid);
+            return filteredService ? getServiceItems([filteredService])[0] : undefined;
         };
     }
 
@@ -469,7 +478,7 @@ export class KubeSummary extends BaseComponent<IKubeSummaryProps, IKubernetesCon
         KubeFactory.getImageLocation = this.props.getImageLocation || KubeFactory.getImageLocation;
     }
 
-    private _selectedItemViewMap: { [selectedItemKey: string]: (selectedItem: any, properties?: { [key: string]: any }) => JSX.Element | null } = {};
+    private _selectedItemViewMap: { [selectedItemKey: string]: (selectedItem: any, selectedItemUid?: string, properties?: { [key: string]: any }) => JSX.Element | null } = {};
     private _objectFinder: { [selectedItemKey: string]: (name: string) => V1ReplicaSet | V1DaemonSet | V1StatefulSet | IServiceItem | undefined } = {};
     private _selectionStore: SelectionStore;
     private _workloadsActionCreator: WorkloadsActionsCreator;

--- a/src/WebUI/Constants.ts
+++ b/src/WebUI/Constants.ts
@@ -36,6 +36,7 @@ export namespace ServicesEvents {
 
 export namespace PodsEvents {
     export const PodsFetchedEvent: string = "ALL_PODS_FETCHED_EVENT";
+    export const LabelledPodsFetchedEvent: string = "LABELLED_PODS_FETCHED_EVENT";
 }
 
 export namespace ImageDetailsEvents {

--- a/src/WebUI/Pods/PodsActions.ts
+++ b/src/WebUI/Pods/PodsActions.ts
@@ -6,6 +6,11 @@
 import { ActionsHubBase, Action } from "../FluxCommon/Actions";
 import { V1PodList } from "@kubernetes/client-node";
 
+export interface IPodListWithLabel {
+    labelSelector: string;
+    podsList: V1PodList;
+}
+
 export class PodsActions extends ActionsHubBase {
     public static getKey(): string {
         return "pods-actions";
@@ -13,17 +18,17 @@ export class PodsActions extends ActionsHubBase {
 
     public initialize(): void {
         this._podsFetched = new Action<V1PodList>();
-        this._podsFetchedByLabel = new Action<V1PodList>();
+        this._podsFetchedByLabel = new Action<IPodListWithLabel>();
     }
 
     public get podsFetched(): Action<V1PodList> {
         return this._podsFetched;
     }
 
-    public get podsFetchedByLabel(): Action<V1PodList> {
+    public get podsFetchedByLabel(): Action<IPodListWithLabel> {
         return this._podsFetchedByLabel;
     }
 
     private _podsFetched: Action<V1PodList>;
-    private _podsFetchedByLabel: Action<V1PodList>;
+    private _podsFetchedByLabel: Action<IPodListWithLabel>;
 }

--- a/src/WebUI/Pods/PodsActionsCreator.ts
+++ b/src/WebUI/Pods/PodsActionsCreator.ts
@@ -22,7 +22,7 @@ export class PodsActionsCreator extends ActionCreatorBase {
         kubeService && kubeService.getPods(labelSelector || undefined).then(podList => {
             this._extendPodMetadataInList(podList);
             if (labelSelector) {
-                this._actions.podsFetchedByLabel.invoke(podList);
+                this._actions.podsFetchedByLabel.invoke({ podsList: podList, labelSelector: labelSelector });
             }
             else {
                 this._actions.podsFetched.invoke(podList);

--- a/src/WebUI/Pods/PodsDetails.tsx
+++ b/src/WebUI/Pods/PodsDetails.tsx
@@ -8,31 +8,118 @@ import { BaseComponent } from "@uifabric/utilities";
 import { SplitterElementPosition, Splitter } from "azure-devops-ui/Splitter";
 import * as React from "react";
 import * as Resources from "../Resources";
-import { IVssComponentProperties } from "../Types";
+import { IVssComponentProperties, IPodDetailsSelectionProperties } from "../Types";
 import { PodsLeftPanel } from "./PodsLeftPanel";
 import { PodsRightPanel } from "./PodsRightPanel";
 import { KubeSummary } from "../Common/KubeSummary";
 import { IImageDetails } from "../../Contracts/Types";
 import { ImageDetails } from "../ImageDetails/ImageDetails";
+import { PodsStore } from "./PodsStore";
+import { StoreManager } from "../FluxCommon/StoreManager";
+import { ActionsCreatorManager } from "../FluxCommon/ActionsCreatorManager";
+import { PodsActionsCreator } from "./PodsActionsCreator";
+import { PodsEvents } from "../Constants";
+import { Utils } from "../Utils";
+import { History, createBrowserHistory } from "history";
+import * as queryString from "query-string";
+import { SelectionActionsCreator } from "../Selection/SelectionActionCreator";
 
 export interface IPodsDetailsProperties extends IVssComponentProperties {
-    pods: V1Pod[];
-    parentName: string;
-    selectedPod?: V1Pod;
-    parentKind: string;
-    onBackButtonClick?: () => void;
+    parentUid: string;
+    serviceSelector?: string;
+    serviceName?: string;
+    selectedPodUid?: string;
 }
 
 export interface IPodsDetailsState {
-    selectedPod: V1Pod | null;
+    pods?: V1Pod[];
+    parentName?: string;
+    parentKind?: string;
+    selectedPod: V1Pod | null | undefined;
     selectedImageDetails: IImageDetails | undefined;
 }
 
 export class PodsDetails extends BaseComponent<IPodsDetailsProperties, IPodsDetailsState> {
     constructor(props: IPodsDetailsProperties) {
-        super(props, {});
+        super(props);
+        this._history = createBrowserHistory();
+        const podsStore = StoreManager.GetStore<PodsStore>(PodsStore);
+        let parentKind: string | undefined = undefined, parentName: string | undefined = undefined, filteredPods: V1Pod[] | undefined = [], selectedPod: V1Pod | undefined = undefined;
+        const podsList = props.serviceSelector ? podsStore.getState().podListByLabel[props.serviceSelector] : podsStore.getState().podsList;
+
+        const getPodProperties = (pods: V1Pod[]): { parentKind?: string, parentName?: string, pods?: V1Pod[], selectedPod?: V1Pod } => {
+            if (pods) {
+                const filteredPods = props.serviceSelector
+                    ? pods
+                    : pods.filter(p => Utils.isOwnerMatched(p.metadata, props.parentUid!.toLowerCase()));
+
+                if (filteredPods.length) {
+                    const selectedPod = props.selectedPodUid ? filteredPods.find(p => p.metadata.uid.toLowerCase() === props.selectedPodUid!.toLowerCase()) : filteredPods[0];
+                    let parentKind: string | undefined = undefined;
+                    let parentName: string | undefined = undefined;
+
+                    if (props.serviceName && props.serviceSelector) {
+                        parentName = props.serviceName;
+                        parentKind = "Service";
+                    } else {
+                        const parent = filteredPods[0].metadata.ownerReferences.find(o => o.uid.toLowerCase() === props.parentUid!.toLowerCase());
+                        if (parent) {
+                            parentKind = parent.kind;
+                            parentName = parent.name;
+                        }
+                    }
+
+                    return {
+                        parentKind: parentKind,
+                        parentName: parentName,
+                        pods: filteredPods,
+                        selectedPod: selectedPod
+                    }
+                }
+            }
+
+            return {};
+        }
+
+        if (!podsList || !podsList.items) {
+            const podsActionCreator = ActionsCreatorManager.GetActionCreator<PodsActionsCreator>(PodsActionsCreator);
+
+            const storeEventName = props.serviceSelector ? PodsEvents.LabelledPodsFetchedEvent : PodsEvents.PodsFetchedEvent;
+            const podsFetchHandler = () => {
+                podsStore.removeListener(storeEventName, podsFetchHandler);
+                const fetchedPodList = props.serviceSelector ? podsStore.getState().podListByLabel[props.serviceSelector] : podsStore.getState().podsList;
+                if (fetchedPodList && fetchedPodList.items) {
+                    const properties = getPodProperties(fetchedPodList.items);
+                    this.setState({
+                        parentKind: properties.parentKind,
+                        parentName: properties.parentName,
+                        pods: properties.pods,
+                        selectedPod: properties.selectedPod
+                    });
+                }
+            }
+
+            podsStore.addListener(storeEventName, podsFetchHandler);
+            if (props.serviceSelector) {
+                podsActionCreator.getPods(KubeSummary.getKubeService(), props.serviceSelector);
+            }
+            else {
+                podsActionCreator.getPods(KubeSummary.getKubeService());
+            }
+        }
+        else {
+            const properties = getPodProperties(podsList.items);
+            parentKind = properties.parentKind;
+            parentName = properties.parentName;
+            filteredPods = properties.pods;
+            selectedPod = properties.selectedPod;
+        }
+
         this.state = {
-            selectedPod: this.props.selectedPod || null,
+            parentKind: parentKind,
+            parentName: parentName,
+            pods: filteredPods,
+            selectedPod: selectedPod,
             selectedImageDetails: undefined
         };
     }
@@ -45,19 +132,19 @@ export class PodsDetails extends BaseComponent<IPodsDetailsProperties, IPodsDeta
         }
 
         let selectedPod = this.state.selectedPod;
-        if (!selectedPod && this.props.pods && this.props.pods.length > 0) {
-            selectedPod = this.props.pods[0];
+        if (!selectedPod && this.state.pods && this.state.pods.length > 0) {
+            selectedPod = this.state.pods[0];
         }
 
-        const leftPanel = (
+        const leftPanel = this.state.pods ? (
             <PodsLeftPanel
-                pods={this.props.pods}
-                parentName={this.props.parentName}
-                parentKind={this.props.parentKind}
+                pods={this.state.pods}
+                parentName={this.state.parentName || ""}
+                parentKind={this.state.parentKind || ""}
                 selectedPodName={selectedPod ? selectedPod.metadata.name : ""}
                 onSelectionChange={this._onPodSelectionChange}
-                onBackButtonClick={this.props.onBackButtonClick} />
-        );
+                onBackButtonClick={this._onParentBackButtonClick} />
+        ) : undefined;
 
         const rightPanel = (selectedPod ?
             <PodsRightPanel
@@ -66,21 +153,48 @@ export class PodsDetails extends BaseComponent<IPodsDetailsProperties, IPodsDeta
             : <div className="zero-pods-text-container">{Resources.NoPodsFoundText}</div>);
 
         return (
-            <Splitter
-                fixedElement={SplitterElementPosition.Near}
-                initialFixedSize={this._initialFixedSize}
-                minFixedSize={this._initialFixedSize}
-                onRenderFarElement={() => rightPanel}
-                onRenderNearElement={() => leftPanel}
-                nearElementClassName="pods-details-left-pane"
-            />);
+            <>
+                {
+                    leftPanel
+                        ? (<Splitter
+                            fixedElement={SplitterElementPosition.Near}
+                            initialFixedSize={this._initialFixedSize}
+                            minFixedSize={this._initialFixedSize}
+                            onRenderFarElement={() => rightPanel}
+                            onRenderNearElement={() => leftPanel}
+                            nearElementClassName="pods-details-left-pane"
+                        />)
+                        : rightPanel
+                }
+            </>
+        );
     }
 
 
     private _onPodSelectionChange = (event: React.SyntheticEvent<HTMLElement>, selectedPod: V1Pod): void => {
+        let routeValues: queryString.OutputParams = queryString.parse(this._history.location.search);
+        routeValues["uid"] = selectedPod.metadata.uid;
+
+        this._history.replace({
+            pathname: this._history.location.pathname,
+            search: queryString.stringify(routeValues)
+        });
+
+
         this.setState({
             selectedPod: selectedPod
         });
+    }
+
+    private _onParentBackButtonClick = () => {
+        const selectionActionCreator = ActionsCreatorManager.GetActionCreator<SelectionActionsCreator>(SelectionActionsCreator);
+        selectionActionCreator.selectItem({
+            itemUID: this.props.parentUid,
+            selectedItemType: Utils.getItemTypeKeyFromKind(this.state.parentKind || ""),
+            showSelectedItem: true,
+            item: undefined,
+            properties: { parentUid: "", serviceSelector: "", serviceName: "" } as IPodDetailsSelectionProperties // This will delete these values if they are present in the url
+        })
     }
 
     // ToDO:: Handle GetImageDetails via ImageStore to avoid multiple calls to API from UI
@@ -100,4 +214,5 @@ export class PodsDetails extends BaseComponent<IPodsDetailsProperties, IPodsDeta
     }
 
     private _initialFixedSize: number = 320;
+    private _history: History;
 }

--- a/src/WebUI/Selection/SelectionActionCreator.ts
+++ b/src/WebUI/Selection/SelectionActionCreator.ts
@@ -29,6 +29,23 @@ export class SelectionActionsCreator extends ActionCreatorBase {
             delete routeValues["view"];
         }
 
+        // This logic needs some refining. We need to plan a course of action that will suit an open source hosting. The host might have its own query parameters
+        // So, our design should be careful in handling those
+        if (payload.properties) {
+            // Add all the non-object, non-function and defined values to the url route. This will be read by the view loading itself
+            Object.keys(payload.properties).forEach(k => {
+                const value = payload.properties![k];
+                if (!!value && typeof value !== "object" && typeof value !== "function") {
+                    routeValues[k] = value;
+                }
+
+                // We will send undefined or empty for values that we want deleted from the url
+                if (!value) {
+                    delete routeValues[k];
+                }
+            });
+        }
+
         this._historyService.push({
             pathname: this._historyService.location.pathname,
             search: queryString.stringify(routeValues)

--- a/src/WebUI/Services/ServicesStore.ts
+++ b/src/WebUI/Services/ServicesStore.ts
@@ -7,7 +7,7 @@ import { StoreBase } from "../FluxCommon/Store";
 import { ActionsHubManager } from "../FluxCommon/ActionsHubManager";
 import { V1ServiceList, V1PodList, V1Pod } from "@kubernetes/client-node";
 import { ServicesActions } from "./ServicesActions";
-import { PodsActions } from "../Pods/PodsActions";
+import { PodsActions, IPodListWithLabel } from "../Pods/PodsActions";
 import { ServicesEvents } from "../Constants";
 
 export interface IServicesStoreState {
@@ -53,8 +53,8 @@ export class ServicesStore extends StoreBase {
         }
     }
 
-    private _setAssociatedPodsList = (podsList: V1PodList): void => {
-        this._state.podsList = podsList && podsList.items;
+    private _setAssociatedPodsList = (payload: IPodListWithLabel): void => {
+        this._state.podsList = payload.podsList && payload.podsList.items;
         this.emit(ServicesEvents.ServicePodsFetchedEvent, this);
     }
 

--- a/src/WebUI/Types.d.ts
+++ b/src/WebUI/Types.d.ts
@@ -71,10 +71,9 @@ export interface ISetWorkloadTypeItem {
 }
 
 export interface IPodDetailsSelectionProperties {
-    pods: V1Pod[];
-    parentItemKind: string;
-    parentItemName: string;
-    onBackClick: () => void;
+    parentUid: string;
+    serviceSelector?: string;
+    serviceName?: string;
 }
 
 export interface IVssComponentProperties extends IBaseProps {

--- a/src/WebUI/Utils.ts
+++ b/src/WebUI/Utils.ts
@@ -11,6 +11,7 @@ import { ILabelModel } from "azure-devops-ui/Label";
 import { IStatusProps, Statuses } from "azure-devops-ui/Status";
 import { PodPhase } from "../Contracts/Contracts";
 import * as Resources from "./Resources";
+import { SelectedItemKeys } from "./Constants";
 
 const pipelineNameAnnotationKey: string = "azure-pipelines/pipeline";
 const pipelineRunIdAnnotationKey: string = "azure-pipelines/execution";
@@ -31,7 +32,7 @@ export class Utils {
     public static isOwnerMatched(objectMeta: V1ObjectMeta, ownerUIdLowerCase: string): boolean {
         return objectMeta.ownerReferences
             && objectMeta.ownerReferences.length > 0
-            && objectMeta.ownerReferences[0].uid.toLowerCase() === ownerUIdLowerCase;
+            && objectMeta.ownerReferences.some(o => o.uid.toLowerCase() === ownerUIdLowerCase);
     }
 
     public static getUILabelModelArray(items: { [key: string]: string }): ObservableArray<ILabelModel> {
@@ -273,5 +274,35 @@ export class Utils {
 
     public static extractDisplayImageName(imageId: string): string {
         return Utils.getImageResourceUrlParameter(imageId, matchPatternForImageName);
+    }
+
+    /**
+     * We will deprecate this function as soon as we decide on a better mapping. Temporarily using this
+     * @param kind 
+     */
+    public static getItemTypeKeyFromKind(kind: string): SelectedItemKeys | "" {
+        switch (kind) {
+            case "ReplicaSet": return SelectedItemKeys.ReplicaSetKey;
+            case "DaemonSet": return SelectedItemKeys.DaemonSetKey;
+            case "StatefulSet": return SelectedItemKeys.StatefulSetKey;
+            case "Service": return SelectedItemKeys.ServiceItemKey;
+            case "Pod": return SelectedItemKeys.OrphanPodKey;
+            default: return "";
+        }
+    }
+
+    /**
+     * We will deprecate this function as soon as we decide on a better mapping. Temporarily using this
+     * @param typeKey 
+     */
+    public static getKindFromItemTypeKey(typeKey: SelectedItemKeys): string {
+        switch (typeKey) {
+            case SelectedItemKeys.DaemonSetKey: return "DaemonSet";
+            case SelectedItemKeys.ReplicaSetKey: return "ReplicaSet";
+            case SelectedItemKeys.StatefulSetKey: return "StatefulSet";
+            case SelectedItemKeys.OrphanPodKey: return "Pod";
+            case SelectedItemKeys.ServiceItemKey: return "Service";
+            default: return "";
+        }
     }
 }

--- a/src/WebUI/WorkLoads/DeploymentsTable.tsx
+++ b/src/WebUI/WorkLoads/DeploymentsTable.tsx
@@ -260,7 +260,7 @@ export class DeploymentsTable extends BaseComponent<IDeploymentsTableProperties,
         const podslist = StoreManager.GetStore<PodsStore>(PodsStore).getState().podsList;
         const relevantPods = (podslist && podslist.items && podslist.items.filter(p => (replicaSet && Utils.isOwnerMatched(p.metadata, replicaSet.metadata.uid)) || false))
 
-        const _onPodsClicked = (relevantPods && replicaSet) ? (() => onPodsColumnClicked(relevantPods, replicaSet, "ReplicaSet", SelectedItemKeys.ReplicaSetKey, this._selectionActionCreator)) : undefined;
+        const _onPodsClicked = (relevantPods && replicaSet) ? (() => onPodsColumnClicked(relevantPods, replicaSet, "ReplicaSet", this._selectionActionCreator)) : undefined;
 
         return renderPodsStatusTableCell(rowIndex, columnIndex, tableColumn, deployment.pods, deployment.statusProps, deployment.podsTooltip, _onPodsClicked);
     }

--- a/src/WebUI/WorkLoads/OtherWorkloadsTable.tsx
+++ b/src/WebUI/WorkLoads/OtherWorkloadsTable.tsx
@@ -246,22 +246,8 @@ export class OtherWorkloads extends BaseComponent<IOtherWorkloadsProperties, IOt
         const podslist = StoreManager.GetStore<PodsStore>(PodsStore).getState().podsList;
         const relevantPods = (podslist && podslist.items && podslist.items.filter(p => (payload && Utils.isOwnerMatched(p.metadata, payload.metadata.uid)) || false))
 
-        let type = "";
-        switch (workload.kind) {
-            case SelectedItemKeys.DaemonSetKey:
-                type = "DaemonSet";
-                break;
-            case SelectedItemKeys.ReplicaSetKey:
-                type = "ReplicaSet";
-                break;
-            case SelectedItemKeys.StatefulSetKey:
-                type = "StatefulSet";
-                break;
-            case SelectedItemKeys.OrphanPodKey:
-                type = "Pod";
-                break;
-        }
-        const _onPodsClicked = (relevantPods && payload) ? (() => onPodsColumnClicked(relevantPods, payload, type, workload.kind as SelectedItemKeys, this._selectionActionCreator)) : undefined;
+        let type = Utils.getKindFromItemTypeKey(workload.kind as SelectedItemKeys);
+        const _onPodsClicked = (relevantPods && payload) ? (() => onPodsColumnClicked(relevantPods, payload, type, this._selectionActionCreator)) : undefined;
 
         return renderPodsStatusTableCell(rowIndex, columnIndex, tableColumn, pods, statusProps, podsTooltip, _onPodsClicked);
     }

--- a/src/WebUI/WorkLoads/WorkloadDetails.tsx
+++ b/src/WebUI/WorkLoads/WorkloadDetails.tsx
@@ -24,7 +24,6 @@ import { Tags } from "../Common/Tags";
 import { StoreManager } from "../FluxCommon/StoreManager";
 import { ImageDetails } from "../ImageDetails/ImageDetails";
 import { ImageDetailsStore } from "../ImageDetails/ImageDetailsStore";
-import { PodsDetails } from "../Pods/PodsDetails";
 import { PodsStore } from "../Pods/PodsStore";
 import { PodsTable } from "../Pods/PodsTable";
 import * as Resources from "../Resources";
@@ -86,7 +85,7 @@ export class WorkloadDetails extends BaseComponent<IWorkloadDetailsProperties, I
             if (queryParams.type) {
                 // function to make sure we get the item for the view if present, or we make a call and set up a store listener to fetch that item
                 const getItem = (getItemList: () => (V1ReplicaSetList | V1StatefulSetList | V1DaemonSetList | undefined), actionCreatorFunc: (k: IKubeService) => void, storeEvent: string) => {
-                    
+
                     // function to search the relevant item from the item list provided
                     const searchItem = () => {
                         const itemList = getItemList();
@@ -305,15 +304,12 @@ export class WorkloadDetails extends BaseComponent<IWorkloadDetailsProperties, I
         const selectionActionCreator = ActionsCreatorManager.GetActionCreator<SelectionActionsCreator>(SelectionActionsCreator);
         selectionActionCreator.selectItem(
             {
-                item: pod,
+                item: undefined,
                 itemUID: pod.metadata.uid,
                 selectedItemType: SelectedItemKeys.PodDetailsKey,
                 showSelectedItem: true,
                 properties: {
-                    parentItemKind: this.props.parentKind,
-                    pods: this.state.pods,
-                    parentItemName: this.state.item!.metadata.name,
-                    onBackClick: () => selectionActionCreator.selectItem({ item: this.state.item, showSelectedItem: true, itemUID: this.state.item!.metadata.uid, selectedItemType: this.props.itemTypeKey })
+                    parentUid: this.state.item!.metadata.uid,
                 } as IPodDetailsSelectionProperties
             }
         );

--- a/tests/WebUI/Utils.test.ts
+++ b/tests/WebUI/Utils.test.ts
@@ -40,7 +40,7 @@ describe("Utils isOwnerMatched Tests", () => {
                 ]
             },
             "f310d74e-ebfd-11e8-ac56-829606b05f65",
-            false
+            true
         ],
     ];
 


### PR DESCRIPTION
This will ensure the following
- If a url is shared, when the user is on pod-details, it will open pod-details for the person who opens it
- We have a link to directly land into logs or yaml
- Back forward involving pods will be smooth for views involving pods