### PR TITLE
add containername to podlog call

### DIFF
--- a/src/Contracts/Contracts.ts
+++ b/src/Contracts/Contracts.ts
@@ -19,7 +19,7 @@ export interface IKubeService {
 
     getStatefulSets(): Promise<K8sTypes.V1StatefulSetList>;
 
-    getPodLog(podName: string): Promise<string>;
+    getPodLog(podName: string, podContainerName?: string): Promise<string>;
 }
 
 export enum KubeImage {

--- a/src/Contracts/KubeServiceBase.ts
+++ b/src/Contracts/KubeServiceBase.ts
@@ -40,7 +40,7 @@ export abstract class KubeServiceBase implements IKubeService {
         return this.fetch(KubeResourceType.StatefulSets);
     }
 
-    abstract getPodLog(podName: string): Promise<string>;
+    abstract getPodLog(podName: string, podContainerName?: string): Promise<string>;
 
     abstract fetch(resourceType: KubeResourceType, labelSelector?: string): Promise<any>;
 }

--- a/src/WebUI/Pods/PodLog.tsx
+++ b/src/WebUI/Pods/PodLog.tsx
@@ -42,7 +42,7 @@ export class PodLog extends BaseComponent<IPodLogProps, IPodLogState> {
     public componentDidMount(): void {
         const service = KubeSummary.getKubeService();
         const podName = this.props.pod.metadata.name;
-        const spec = this.props.pod.spec || {};
+        const spec = this.props.pod.spec || undefined;
         const podContainerName = spec && spec.containers && spec.containers.length > 0 && spec.containers[0].name || "";
 
         service && service.getPodLog && service.getPodLog(podName, podContainerName).then(logContent => {

--- a/src/WebUI/Pods/PodLog.tsx
+++ b/src/WebUI/Pods/PodLog.tsx
@@ -41,7 +41,11 @@ export class PodLog extends BaseComponent<IPodLogProps, IPodLogState> {
 
     public componentDidMount(): void {
         const service = KubeSummary.getKubeService();
-        service && service.getPodLog && service.getPodLog(this.props.pod.metadata.name).then(logContent => {
+        const podName = this.props.pod.metadata.name;
+        const spec = this.props.pod.spec || {};
+        const podContainerName = spec && spec.containers && spec.containers.length > 0 && spec.containers[0].name || "";
+
+        service && service.getPodLog && service.getPodLog(podName, podContainerName).then(logContent => {
             this.setState({
                 uid: Util_String.newGuid(), // required to refresh the content
                 logContent: logContent || ""


### PR DESCRIPTION
We need a way to send the containerName for the pod to get the logs, this is required for a pod which has more than one container in the spec.