### PR TITLE
Add a prop to handle view changed in the host of k8s summary

### DIFF
--- a/src/WebUI/Common/KubeFilterBar.tsx
+++ b/src/WebUI/Common/KubeFilterBar.tsx
@@ -41,7 +41,7 @@ export class KubeFilterBar extends BaseComponent<IFilterComponentProperties, {}>
         return (
             <ConditionalChildren renderChildren={this.props.filterToggled}>
                 <FilterBar filter={this.props.filter} className={this.props.className || ""}>
-                    <KeywordFilterBarItem filterItemKey={NameKey} placeholder={localeFormat(Resources.FindByNameText, this.props.keywordPlaceHolder)} />
+                    <KeywordFilterBarItem filterItemKey={NameKey} className={"keyword-search"} placeholder={localeFormat(Resources.FindByNameText, this.props.keywordPlaceHolder)} />
                     <PickListFilterBarItem
                         placeholder={this.props.pickListPlaceHolder}
                         showPlaceholderAsLabel={true}

--- a/src/WebUI/Common/KubeSummary.scss
+++ b/src/WebUI/Common/KubeSummary.scss
@@ -3,4 +3,9 @@
     .k8s-card-padding+.k8s-card-padding {
         margin-top: 16px;
     }
+
+    /*Css to adjust the alignment of text between picklist and text search. Revisit when we move from picklist to dropdown (fabric-free)*/
+    .keyword-search.bolt-text-field{
+        padding-bottom: 8px;
+    }
 }

--- a/src/WebUI/Services/ServiceDetails.tsx
+++ b/src/WebUI/Services/ServiceDetails.tsx
@@ -38,6 +38,7 @@ import { SelectionActionsCreator } from "../Selection/SelectionActionCreator";
 export interface IServiceDetailsProperties extends IVssComponentProperties {
     service: IServiceItem | undefined;
     parentKind: string;
+    notifyViewChanged?: (viewTree: { id: string, displayName: string, url: string }[]) => void;
 }
 
 export interface IServiceDetailsState {
@@ -54,6 +55,17 @@ export class ServiceDetails extends BaseComponent<IServiceDetailsProperties, ISe
             service: props.service,
             pods: []
         };
+
+        const notifyViewChanged = (service: V1Service) => {
+            if (service.metadata && props.notifyViewChanged) {
+                const metadata = service.metadata;
+                props.notifyViewChanged([{ id: SelectedItemKeys.ServiceItemKey + metadata.uid, displayName: metadata.name, url: window.location.href }]);
+            }
+        }
+
+        if (props.service && props.service.service) {
+            notifyViewChanged(props.service.service);
+        }
 
         this._podsActionsCreator = ActionsCreatorManager.GetActionCreator<PodsActionsCreator>(PodsActionsCreator);
         this._servicesStore = StoreManager.GetStore<ServicesStore>(ServicesStore);
@@ -73,6 +85,7 @@ export class ServiceDetails extends BaseComponent<IServiceDetailsProperties, ISe
                 const services = (servicesList && servicesList.items) || [];
                 const selectedService = services.find(s => s.metadata.uid === queryParams.uid);
                 if (selectedService) {
+                    notifyViewChanged(selectedService);
                     fetchServiceDetails(selectedService);
                     this.setState({
                         service: getServiceItems([selectedService])[0]


### PR DESCRIPTION
Adding a prop to k8s summary that is invoked whenever there is a change in the view. The prop is a callback that would be invoked when we are changing views. It would contain the depth wise tree of the current view. Since at the moment there is only one level of depth available, there would only be one item sent for the view change, but this may be added later. 

- Additionally added a css fix in the filter bars