### PR TITLE
Added support to show latest tag for image names by default

### DIFF
--- a/src/WebUI/Pods/PodsDetails.tsx
+++ b/src/WebUI/Pods/PodsDetails.tsx
@@ -113,6 +113,8 @@ export class PodsDetails extends BaseComponent<IPodsDetailsProperties, IPodsDeta
                 const fetchedPodList = props.serviceSelector ? podsStore.getState().podListByLabel[props.serviceSelector] : podsStore.getState().podsList;
                 if (fetchedPodList && fetchedPodList.items) {
                     const properties = getPodProperties(fetchedPodList.items);
+                    // Adding breadcrumb when parent object is fetched on pod view refresh
+                    notifyViewChanged(properties.parentName, properties.parentKind);
                     this.setState({
                         parentKind: properties.parentKind,
                         parentName: properties.parentName,

--- a/src/WebUI/Utils.ts
+++ b/src/WebUI/Utils.ts
@@ -150,7 +150,7 @@ export class Utils {
         if (podSpec && podSpec.containers && podSpec.containers.length > 0) {
             podSpec.containers.forEach(container => {
                 if (images.indexOf(container.image) < 0) {
-                    images.push(container.image);
+                    images.push(Utils.appendDefaultTagToImageName(container.image));
                 }
             });
 
@@ -167,7 +167,7 @@ export class Utils {
 
     public static getFirstImageName(podSpec: V1PodSpec | undefined): string {
         if (podSpec && podSpec.containers && podSpec.containers.length > 0) {
-            return podSpec.containers[0].image;
+            return Utils.appendDefaultTagToImageName(podSpec.containers[0].image);
         }
 
         return "";
@@ -269,7 +269,16 @@ export class Utils {
     }
 
     public static extractDisplayImageName(imageId: string): string {
-        return Utils.getImageResourceUrlParameter(imageId, matchPatternForImageName);
+        let imageName = Utils.getImageResourceUrlParameter(imageId, matchPatternForImageName);
+        return Utils.appendDefaultTagToImageName(imageName);
+    }
+
+    public static appendDefaultTagToImageName(imageName: string): string {
+        if(!/:/.test(imageName)) {
+            imageName = format("{0}:latest", imageName);
+        }
+
+        return imageName;
     }
 
     /**


### PR DESCRIPTION
Append the tag latest to image name's repository if no tag is present
![image](https://user-images.githubusercontent.com/12389221/56026505-e64b8380-5d31-11e9-9262-e0e445311e9a.png)
