### PR TITLE
Added Loading experience for Services and Associated Pods in Services…

### DIFF
--- a/src/WebUI/Common/KubeSummary.scss
+++ b/src/WebUI/Common/KubeSummary.scss
@@ -8,4 +8,8 @@
     .keyword-search.bolt-text-field{
         padding-bottom: 8px;
     }
+
+    .loading-pods {
+        height: 200px;
+    }
 }

--- a/src/WebUI/ImageDetails/ImageDetails.tsx
+++ b/src/WebUI/ImageDetails/ImageDetails.tsx
@@ -201,6 +201,7 @@ export class ImageDetails extends BaseComponent<IImageDetailsProperties, IImageD
 
     private _getImageLayers(): JSX.Element | null {
         const imageDetails = this.props.imageDetails;
+        const layerInfo = this._sortByCreatedDate(imageDetails.layerInfo);
         return (
             <CustomCard className="image-layers-card k8s-card-padding bolt-table-card flex-grow bolt-card-no-vertical-padding">
                 <CustomHeader>
@@ -215,7 +216,7 @@ export class ImageDetails extends BaseComponent<IImageDetailsProperties, IImageD
                 <CardContent className="image-layer-details" contentPadding={false}>
                     <Table
                         id="image-layers-table"
-                        itemProvider={new ArrayItemProvider<IImageLayer>(imageDetails.layerInfo)}
+                        itemProvider={new ArrayItemProvider<IImageLayer>(layerInfo)}
                         columns={ImageDetails._getImageLayersColumns()}
                         showHeader={true}
                         showLines={true}
@@ -224,6 +225,20 @@ export class ImageDetails extends BaseComponent<IImageDetailsProperties, IImageD
                 </CardContent>
             </CustomCard>
         );
+    }
+
+    private getTime(date?: Date) {
+        return date != null ? date.getTime() : 0;
+    }
+
+
+    private _sortByCreatedDate(layerInfo : IImageLayer[]): IImageLayer[] {
+        layerInfo.sort((a: IImageLayer, b: IImageLayer) => {
+            // Most recent layer to be shown first
+            return this.getTime(b.createdOn) - this.getTime(a.createdOn);
+        });
+
+        return layerInfo;
     }
 
     private static _getImageLayersColumns(): ITableColumn<IImageLayer>[] {
@@ -277,7 +292,11 @@ export class ImageDetails extends BaseComponent<IImageDetailsProperties, IImageD
 
     private static _renderLayersSizeCell(rowIndex: number, columnIndex: number, tableColumn: ITableColumn<IImageLayer>, imageLayer: IImageLayer): JSX.Element {
         // Currently size data is not present in imageLayer
-        const textToRender = imageLayer.size || "-";
+        let textToRender = imageLayer.size;
+        if(!textToRender || textToRender.toUpperCase() === "0B"){
+            textToRender = "-";
+        }
+
         const itemToRender = defaultColumnRenderer(textToRender);
         return renderTableCell(rowIndex, columnIndex, tableColumn, itemToRender);
     }

--- a/src/WebUI/Pods/PodsActions.ts
+++ b/src/WebUI/Pods/PodsActions.ts
@@ -6,9 +6,13 @@
 import { ActionsHubBase, Action } from "../FluxCommon/Actions";
 import { V1PodList } from "@kubernetes/client-node";
 
-export interface IPodListWithLabel {
-    labelSelector: string;
+export interface IPodsPayload {
     podsList: V1PodList;
+    podsLoading: boolean;
+}
+
+export interface IPodListWithLabel extends IPodsPayload {
+    labelSelector: string;
 }
 
 export class PodsActions extends ActionsHubBase {
@@ -17,11 +21,11 @@ export class PodsActions extends ActionsHubBase {
     }
 
     public initialize(): void {
-        this._podsFetched = new Action<V1PodList>();
+        this._podsFetched = new Action<IPodsPayload>();
         this._podsFetchedByLabel = new Action<IPodListWithLabel>();
     }
 
-    public get podsFetched(): Action<V1PodList> {
+    public get podsFetched(): Action<IPodsPayload> {
         return this._podsFetched;
     }
 
@@ -29,6 +33,6 @@ export class PodsActions extends ActionsHubBase {
         return this._podsFetchedByLabel;
     }
 
-    private _podsFetched: Action<V1PodList>;
+    private _podsFetched: Action<IPodsPayload>;
     private _podsFetchedByLabel: Action<IPodListWithLabel>;
 }

--- a/src/WebUI/Pods/PodsActions.ts
+++ b/src/WebUI/Pods/PodsActions.ts
@@ -8,7 +8,7 @@ import { V1PodList } from "@kubernetes/client-node";
 
 export interface IPodsPayload {
     podsList: V1PodList;
-    podsLoading: boolean;
+    isLoading: boolean;
 }
 
 export interface IPodListWithLabel extends IPodsPayload {

--- a/src/WebUI/Pods/PodsActionsCreator.ts
+++ b/src/WebUI/Pods/PodsActionsCreator.ts
@@ -22,10 +22,10 @@ export class PodsActionsCreator extends ActionCreatorBase {
         kubeService && kubeService.getPods(labelSelector || undefined).then(podList => {
             this._extendPodMetadataInList(podList);
             if (labelSelector) {
-                this._actions.podsFetchedByLabel.invoke({ podsList: podList, labelSelector: labelSelector, podsLoading: false });
+                this._actions.podsFetchedByLabel.invoke({ podsList: podList, labelSelector: labelSelector, isLoading: false });
             }
             else {
-                this._actions.podsFetched.invoke({ podsList: podList, podsLoading: false });
+                this._actions.podsFetched.invoke({ podsList: podList, isLoading: false });
             }
         });
     }

--- a/src/WebUI/Pods/PodsActionsCreator.ts
+++ b/src/WebUI/Pods/PodsActionsCreator.ts
@@ -22,10 +22,10 @@ export class PodsActionsCreator extends ActionCreatorBase {
         kubeService && kubeService.getPods(labelSelector || undefined).then(podList => {
             this._extendPodMetadataInList(podList);
             if (labelSelector) {
-                this._actions.podsFetchedByLabel.invoke({ podsList: podList, labelSelector: labelSelector });
+                this._actions.podsFetchedByLabel.invoke({ podsList: podList, labelSelector: labelSelector, podsLoading: false });
             }
             else {
-                this._actions.podsFetched.invoke(podList);
+                this._actions.podsFetched.invoke({ podsList: podList, podsLoading: false });
             }
         });
     }

--- a/src/WebUI/Pods/PodsDetails.tsx
+++ b/src/WebUI/Pods/PodsDetails.tsx
@@ -37,7 +37,7 @@ export interface IPodsDetailsState {
     pods?: V1Pod[];
     parentName?: string;
     parentKind?: string;
-    podsLoading?: boolean;
+    isLoading?: boolean;
     selectedPod: V1Pod | null | undefined;
     selectedImageDetails: IImageDetails | undefined;
 }
@@ -121,7 +121,7 @@ export class PodsDetails extends BaseComponent<IPodsDetailsProperties, IPodsDeta
                         parentName: properties.parentName,
                         pods: properties.pods,
                         selectedPod: properties.selectedPod,
-                        podsLoading: podsStoreState.podsLoading
+                        isLoading: podsStoreState.isLoading
                     });
                 }
             }
@@ -159,7 +159,7 @@ export class PodsDetails extends BaseComponent<IPodsDetailsProperties, IPodsDeta
                 onBackButtonClick={this._hideImageDetails} />;
         }
 
-        if (this.state.podsLoading) {
+        if (this.state.isLoading) {
             return <Spinner className={"flex flex-grow loading-pods"}
                 size={SpinnerSize.large}
                 label={Resources.LoadingPodsSpinnerLabel} />;
@@ -188,18 +188,16 @@ export class PodsDetails extends BaseComponent<IPodsDetailsProperties, IPodsDeta
 
         return (
             <>
-            {
-                leftPanel
-                    ?(<Splitter
-                            fixedElement= { SplitterElementPosition.Near }
-        initialFixedSize = { this._initialFixedSize }
-        minFixedSize = { this._initialFixedSize }
-        onRenderFarElement = {() => rightPanel
-    }
-    onRenderNearElement = {() => leftPanel
-}
-nearElementClassName = "pods-details-left-pane"
-    />)
+                {
+                    leftPanel
+                        ? (<Splitter
+                            fixedElement={SplitterElementPosition.Near}
+                            initialFixedSize={this._initialFixedSize}
+                            minFixedSize={this._initialFixedSize}
+                            onRenderFarElement={() => rightPanel}
+                            onRenderNearElement={() => leftPanel}
+                            nearElementClassName="pods-details-left-pane"
+                        />)
                         : rightPanel
                 }
             </>

--- a/src/WebUI/Pods/PodsStore.ts
+++ b/src/WebUI/Pods/PodsStore.ts
@@ -11,7 +11,7 @@ import { PodsEvents } from "../Constants";
 
 export interface IPodsStoreState {
     podsList?: V1PodList;
-    podsLoading?: boolean;
+    isLoading?: boolean;
     podListByLabel: { [label: string]: V1PodList };
 }
 
@@ -23,7 +23,7 @@ export class PodsStore extends StoreBase {
     public initialize(instanceId?: string): void {
         super.initialize(instanceId);
 
-        this._state = { podsList: undefined, podListByLabel: {}, podsLoading: true };
+        this._state = { podsList: undefined, podListByLabel: {}, isLoading: true };
 
         this._actions = ActionsHubManager.GetActionsHub<PodsActions>(PodsActions);
         this._actions.podsFetched.addListener(this._setPodsList);
@@ -41,13 +41,13 @@ export class PodsStore extends StoreBase {
 
     private _setPodsList = (payload: IPodsPayload): void => {
         this._state.podsList = payload.podsList;
-        this._state.podsLoading = payload.podsLoading;
+        this._state.isLoading = payload.isLoading;
         this.emit(PodsEvents.PodsFetchedEvent, this);
     }
 
     private _setPodsListByLabel = (payload: IPodListWithLabel): void => {
         this._state.podListByLabel[payload.labelSelector] = payload.podsList;
-        this._state.podsLoading = payload.podsLoading;
+        this._state.isLoading = payload.isLoading;
         this.emit(PodsEvents.LabelledPodsFetchedEvent, this);
     }
 

--- a/src/WebUI/Pods/PodsStore.ts
+++ b/src/WebUI/Pods/PodsStore.ts
@@ -6,11 +6,12 @@
 import { StoreBase } from "../FluxCommon/Store";
 import { ActionsHubManager } from "../FluxCommon/ActionsHubManager";
 import { V1PodList, V1Pod } from "@kubernetes/client-node";
-import { PodsActions, IPodListWithLabel } from "./PodsActions";
+import { PodsActions, IPodListWithLabel, IPodsPayload } from "./PodsActions";
 import { PodsEvents } from "../Constants";
 
 export interface IPodsStoreState {
     podsList?: V1PodList;
+    podsLoading?: boolean;
     podListByLabel: { [label: string]: V1PodList };
 }
 
@@ -22,29 +23,31 @@ export class PodsStore extends StoreBase {
     public initialize(instanceId?: string): void {
         super.initialize(instanceId);
 
-        this._state = { podsList: undefined, podListByLabel: {} };
+        this._state = { podsList: undefined, podListByLabel: {}, podsLoading: true };
 
         this._actions = ActionsHubManager.GetActionsHub<PodsActions>(PodsActions);
         this._actions.podsFetched.addListener(this._setPodsList);
-        this._actions.podsFetchedByLabel.addListener(this._setPodsListByLabel)
+        this._actions.podsFetchedByLabel.addListener(this._setPodsListByLabel);
     }
 
     public disposeInternal(): void {
         this._actions.podsFetched.removeListener(this._setPodsList);
-        this._actions.podsFetchedByLabel.addListener(this._setPodsListByLabel)
+        this._actions.podsFetchedByLabel.removeListener(this._setPodsListByLabel);
     }
 
     public getState(): IPodsStoreState {
         return this._state;
     }
 
-    private _setPodsList = (podsList: V1PodList): void => {
-        this._state.podsList = podsList;
+    private _setPodsList = (payload: IPodsPayload): void => {
+        this._state.podsList = payload.podsList;
+        this._state.podsLoading = payload.podsLoading;
         this.emit(PodsEvents.PodsFetchedEvent, this);
     }
 
     private _setPodsListByLabel = (payload: IPodListWithLabel): void => {
         this._state.podListByLabel[payload.labelSelector] = payload.podsList;
+        this._state.podsLoading = payload.podsLoading;
         this.emit(PodsEvents.LabelledPodsFetchedEvent, this);
     }
 

--- a/src/WebUI/Resources.d.ts
+++ b/src/WebUI/Resources.d.ts
@@ -91,3 +91,5 @@ export declare const CommandText: string;
 export declare const SizeText: string;
 export declare const SummaryHeaderSubTextFormat: string;
 export declare const TagsText: string;
+export declare const LoadingPodsSpinnerLabel: string;
+export declare const LoadingServicesSpinnerLabel: string;

--- a/src/WebUI/Resources.js
+++ b/src/WebUI/Resources.js
@@ -92,4 +92,6 @@ define("Environments/Providers/Kubernetes/Resources", ["require", "exports"], fu
     exports.SizeText = "Size";
     exports.SummaryHeaderSubTextFormat = "{0} (cluster)";
     exports.TagsText = "Tags";
+    exports.LoadingPodsSpinnerLabel = "Loading pods...";
+    exports.LoadingServicesSpinnerLabel = "Loading services...";
 });

--- a/src/WebUI/Resources.js
+++ b/src/WebUI/Resources.js
@@ -92,6 +92,6 @@ define("Environments/Providers/Kubernetes/Resources", ["require", "exports"], fu
     exports.SizeText = "Size";
     exports.SummaryHeaderSubTextFormat = "{0} (cluster)";
     exports.TagsText = "Tags";
-    exports.LoadingPodsSpinnerLabel = "Loading pods...";
+    exports.LoadingPodsSpinnerLabel = "Loading associated pods...";
     exports.LoadingServicesSpinnerLabel = "Loading services...";
 });

--- a/src/WebUI/Services/ServiceDetails.tsx
+++ b/src/WebUI/Services/ServiceDetails.tsx
@@ -13,6 +13,7 @@ import { Statuses } from "azure-devops-ui/Status";
 import { ITableColumn, renderSimpleCell, Table } from "azure-devops-ui/Table";
 import * as Date_Utils from "azure-devops-ui/Utilities/Date";
 import { ArrayItemProvider } from "azure-devops-ui/Utilities/Provider";
+import { Spinner, SpinnerSize } from "azure-devops-ui/Spinner";
 import * as React from "react";
 import * as queryString from "query-string";
 import { renderTableCell } from "../Common/KubeCardWithTable";
@@ -20,7 +21,7 @@ import { KubeSummary } from "../Common/KubeSummary";
 import { KubeZeroData } from "../Common/KubeZeroData";
 import { PageTopHeader } from "../Common/PageTopHeader";
 import { Tags } from "../Common/Tags";
-import { ServicesEvents, SelectedItemKeys } from "../Constants";
+import { ServicesEvents, PodsEvents, SelectedItemKeys } from "../Constants";
 import { ActionsCreatorManager } from "../FluxCommon/ActionsCreatorManager";
 import { StoreManager } from "../FluxCommon/StoreManager";
 import { PodsActionsCreator } from "../Pods/PodsActionsCreator";
@@ -34,6 +35,7 @@ import { ServicesActionsCreator } from "./ServicesActionsCreator";
 import { createBrowserHistory } from "history";
 import { getServiceItems } from "./ServiceUtils";
 import { SelectionActionsCreator } from "../Selection/SelectionActionCreator";
+import { PodsStore } from "../Pods/PodsStore";
 
 export interface IServiceDetailsProperties extends IVssComponentProperties {
     service: IServiceItem | undefined;
@@ -44,6 +46,7 @@ export interface IServiceDetailsProperties extends IVssComponentProperties {
 export interface IServiceDetailsState {
     service: IServiceItem | undefined;
     pods: Array<V1Pod>;
+    podsLoading?: boolean;
 }
 
 const LoadBalancerText: string = "LoadBalancer";
@@ -53,7 +56,8 @@ export class ServiceDetails extends BaseComponent<IServiceDetailsProperties, ISe
         super(props, {});
         this.state = {
             service: props.service,
-            pods: []
+            pods: [],
+            podsLoading: true
         };
 
         const notifyViewChanged = (service: V1Service) => {
@@ -69,6 +73,7 @@ export class ServiceDetails extends BaseComponent<IServiceDetailsProperties, ISe
 
         this._podsActionsCreator = ActionsCreatorManager.GetActionCreator<PodsActionsCreator>(PodsActionsCreator);
         this._servicesStore = StoreManager.GetStore<ServicesStore>(ServicesStore);
+        this._podsStore = StoreManager.GetStore<PodsStore>(PodsStore);
         const fetchServiceDetails = (svc: V1Service) => {
             // service currently only supports equals with "and" operator. The generator generates that condition.
             const labelSelector: string = Utils.generateEqualsConditionLabelSelector(svc && svc.spec && svc.spec.selector || {});
@@ -170,12 +175,20 @@ export class ServiceDetails extends BaseComponent<IServiceDetailsProperties, ISe
 
     private _onPodsFetched = (): void => {
         const pods = this._servicesStore.getState().podsList;
+        const podsLoading = this._podsStore.getState().podsLoading;
         this.setState({
-            pods: pods || []
+            pods: pods || [],
+            podsLoading: podsLoading
         });
     }
 
     private _getAssociatedPods(): JSX.Element | null {
+        if (this.state.podsLoading) {
+            return <Spinner className={"flex flex-grow loading-pods"}
+                size={SpinnerSize.large}
+                label={Resources.LoadingPodsSpinnerLabel} />;
+        }
+
         if (!this.state.pods || this.state.pods.length === 0) {
             return KubeZeroData.getServiceAssociatedPodsZeroData();
         }
@@ -284,4 +297,5 @@ export class ServiceDetails extends BaseComponent<IServiceDetailsProperties, ISe
 
     private _servicesStore: ServicesStore;
     private _podsActionsCreator: PodsActionsCreator;
+    private _podsStore: PodsStore;
 }

--- a/src/WebUI/Services/ServiceDetails.tsx
+++ b/src/WebUI/Services/ServiceDetails.tsx
@@ -46,7 +46,7 @@ export interface IServiceDetailsProperties extends IVssComponentProperties {
 export interface IServiceDetailsState {
     service: IServiceItem | undefined;
     pods: Array<V1Pod>;
-    podsLoading?: boolean;
+    arePodsLoading?: boolean;
 }
 
 const LoadBalancerText: string = "LoadBalancer";
@@ -57,7 +57,7 @@ export class ServiceDetails extends BaseComponent<IServiceDetailsProperties, ISe
         this.state = {
             service: props.service,
             pods: [],
-            podsLoading: true
+            arePodsLoading: true
         };
 
         const notifyViewChanged = (service: V1Service) => {
@@ -175,15 +175,15 @@ export class ServiceDetails extends BaseComponent<IServiceDetailsProperties, ISe
 
     private _onPodsFetched = (): void => {
         const pods = this._servicesStore.getState().podsList;
-        const podsLoading = this._podsStore.getState().podsLoading;
+        const arePodsLoading = this._podsStore.getState().isLoading;
         this.setState({
             pods: pods || [],
-            podsLoading: podsLoading
+            arePodsLoading: arePodsLoading
         });
     }
 
     private _getAssociatedPods(): JSX.Element | null {
-        if (this.state.podsLoading) {
+        if (this.state.arePodsLoading) {
             return <Spinner className={"flex flex-grow loading-pods"}
                 size={SpinnerSize.large}
                 label={Resources.LoadingPodsSpinnerLabel} />;

--- a/src/WebUI/Services/ServicesPivot.scss
+++ b/src/WebUI/Services/ServicesPivot.scss
@@ -1,0 +1,3 @@
+.loading-services {
+    height: 200px;
+}

--- a/src/WebUI/Services/ServicesPivot.tsx
+++ b/src/WebUI/Services/ServicesPivot.tsx
@@ -26,7 +26,7 @@ import "./ServicesPivot.scss";
 
 export interface IServicesPivotState {
     serviceList?: V1ServiceList;
-    servicesLoading?: boolean;
+    isLoading?: boolean;
 }
 
 export interface IServicesPivotProps extends IVssComponentProperties {
@@ -45,7 +45,7 @@ export class ServicesPivot extends BaseComponent<IServicesPivotProps, IServicesP
         const storeState = this._store.getState();
         this.state = {
             serviceList: storeState.serviceList,
-            servicesLoading: storeState.servicesLoading
+            isLoading: storeState.isLoading
         };
 
         this._actionCreator.getServices(KubeSummary.getKubeService());
@@ -53,16 +53,16 @@ export class ServicesPivot extends BaseComponent<IServicesPivotProps, IServicesP
     }
 
     public render(): React.ReactNode {
-        if (this.state.servicesLoading) {
+        if (this.state.isLoading) {
             return <Spinner className={"flex flex-grow loading-services"} size={SpinnerSize.large} label={Resources.LoadingServicesSpinnerLabel} />;
         }
 
         return (
             <>
-            { this._getFilterBar() }
-            < div className= { css("services-pivot-data", "k8s-pivot-data")} >
-                { this._getContent() }
-                </div >
+                {this._getFilterBar()}
+                <div className={css("services-pivot-data", "k8s-pivot-data")}>
+                    {this._getContent()}
+                </div>
             </>
         );
     }
@@ -75,7 +75,7 @@ export class ServicesPivot extends BaseComponent<IServicesPivotProps, IServicesP
         const storeState = this._store.getState();
         this.setState({
             serviceList: storeState.serviceList,
-            servicesLoading: storeState.servicesLoading
+            isLoading: storeState.isLoading
         });
     }
 

--- a/src/WebUI/Services/ServicesStore.ts
+++ b/src/WebUI/Services/ServicesStore.ts
@@ -13,7 +13,7 @@ import { ServicesEvents } from "../Constants";
 export interface IServicesStoreState {
     serviceList?: V1ServiceList
     podsList?: V1Pod[];
-    servicesLoading?: boolean;
+    isLoading?: boolean;
 }
 
 export class ServicesStore extends StoreBase {
@@ -24,7 +24,7 @@ export class ServicesStore extends StoreBase {
     public initialize(instanceId?: string): void {
         super.initialize(instanceId);
 
-        this._state = { serviceList: undefined, podsList: [], servicesLoading: true };
+        this._state = { serviceList: undefined, podsList: [], isLoading: true };
 
         this._servicesActions = ActionsHubManager.GetActionsHub<ServicesActions>(ServicesActions);
         this._podsActions = ActionsHubManager.GetActionsHub<PodsActions>(PodsActions);
@@ -48,7 +48,7 @@ export class ServicesStore extends StoreBase {
 
     private _servicesFetched = (serviceList: V1ServiceList): void => {
         this._state.serviceList = serviceList;
-        this._state.servicesLoading = false;
+        this._state.isLoading = false;
         this.emit(ServicesEvents.ServicesFetchedEvent, this);
         if (this._state.serviceList && this._state.serviceList.items && this._state.serviceList.items.length > 0) {
             this.emit(ServicesEvents.ServicesFoundEvent, this);

--- a/src/WebUI/Services/ServicesStore.ts
+++ b/src/WebUI/Services/ServicesStore.ts
@@ -13,6 +13,7 @@ import { ServicesEvents } from "../Constants";
 export interface IServicesStoreState {
     serviceList?: V1ServiceList
     podsList?: V1Pod[];
+    servicesLoading?: boolean;
 }
 
 export class ServicesStore extends StoreBase {
@@ -23,7 +24,7 @@ export class ServicesStore extends StoreBase {
     public initialize(instanceId?: string): void {
         super.initialize(instanceId);
 
-        this._state = { serviceList: undefined, podsList: [] };
+        this._state = { serviceList: undefined, podsList: [], servicesLoading: true };
 
         this._servicesActions = ActionsHubManager.GetActionsHub<ServicesActions>(ServicesActions);
         this._podsActions = ActionsHubManager.GetActionsHub<PodsActions>(PodsActions);
@@ -47,6 +48,7 @@ export class ServicesStore extends StoreBase {
 
     private _servicesFetched = (serviceList: V1ServiceList): void => {
         this._state.serviceList = serviceList;
+        this._state.servicesLoading = false;
         this.emit(ServicesEvents.ServicesFetchedEvent, this);
         if (this._state.serviceList && this._state.serviceList.items && this._state.serviceList.items.length > 0) {
             this.emit(ServicesEvents.ServicesFoundEvent, this);

--- a/src/WebUI/WorkLoads/WorkloadDetails.tsx
+++ b/src/WebUI/WorkLoads/WorkloadDetails.tsx
@@ -59,7 +59,7 @@ export interface IWorkloadDetailsState {
     showSelectedPod: boolean;
     showImageDetails: boolean;
     selectedImageDetails: IImageDetails | undefined;
-    podsLoading?: boolean;
+    arePodsLoading?: boolean;
 }
 
 export interface IWorkLoadDetailsItem {
@@ -226,7 +226,7 @@ export class WorkloadDetails extends BaseComponent<IWorkloadDetailsProperties, I
         if (podList && podList.items) {
             this.setState({
                 pods: podList.items.filter(p => this.state.item && Utils.isOwnerMatched(p.metadata, this.state.item.metadata.uid)),
-                podsLoading: podsStoreState.podsLoading
+                arePodsLoading: podsStoreState.isLoading
             });
         }
     }
@@ -306,7 +306,7 @@ export class WorkloadDetails extends BaseComponent<IWorkloadDetailsProperties, I
 
     private _getAssociatedPods(): JSX.Element | null {
         const podsStoreState = this._podsStore.getState();
-        if (podsStoreState.podsLoading) {
+        if (podsStoreState.isLoading) {
             return <Spinner className={"flex flex-grow loading-pods"}
                 size={SpinnerSize.large}
                 label={Resources.LoadingPodsSpinnerLabel} />;

--- a/src/WebUI/WorkLoads/WorkloadsStore.ts
+++ b/src/WebUI/WorkLoads/WorkloadsStore.ts
@@ -7,7 +7,7 @@ import { V1DaemonSetList, V1DeploymentList, V1Pod, V1PodList, V1ReplicaSetList, 
 import { WorkloadsEvents } from "../Constants";
 import { ActionsHubManager } from "../FluxCommon/ActionsHubManager";
 import { StoreBase } from "../FluxCommon/Store";
-import { PodsActions } from "../Pods/PodsActions";
+import { PodsActions, IPodsPayload } from "../Pods/PodsActions";
 import { WorkloadsActions } from "./WorkloadsActions";
 
 export interface IWorkloadsStoreState {
@@ -100,9 +100,9 @@ export class WorkloadsStore extends StoreBase {
         }
     }
 
-    private _setOrphanPodsList = (podsList: V1PodList): void => {
+    private _setOrphanPodsList = (payload: IPodsPayload): void => {
         let orphanPods: V1Pod[] = [];
-        podsList && podsList.items && podsList.items.forEach(pod => {
+        payload.podsList && payload.podsList.items && payload.podsList.items.forEach(pod => {
             if (!pod.metadata.ownerReferences) {
                 orphanPods.push(pod);
             }


### PR DESCRIPTION
test-pod- http://nidabas-desk/DefaultCollection/p1/_serviceEndpoints/172104eb-38d7-40b7-88ed-7e95d242c073/kubernetesSummary?namespace=default
Services Loading- 
![image](https://user-images.githubusercontent.com/12389221/56127072-03828b00-5f9a-11e9-9f08-f9834a736b28.png)
Pods loading-
![image](https://user-images.githubusercontent.com/12389221/56127135-1e54ff80-5f9a-11e9-8b19-6e0db9d06509.png)

Workloads Landing is fetched by data provider, hence loading not required there.
Also show Images Layers information sorted by Created Date-
![image](https://user-images.githubusercontent.com/12389221/56129891-1056ad00-5fa1-11e9-9eb9-94da1d872eee.png)
