### PR TITLE
Prevent row click to be triggered for image link click

### DIFF
--- a/src/WebUI/Pods/PodOverview.tsx
+++ b/src/WebUI/Pods/PodOverview.tsx
@@ -136,7 +136,7 @@ export class PodOverview extends BaseComponent<IPodOverviewProps> {
                 props = {
                     columnIndex: columnIndex,
                     children:
-                        <Tags items={value} />,
+                    <Tags items={value} />,
                     tableColumn: tableColumn,
                     contentClassName: css("pod-labels-pill", contentClassName)
                 };
@@ -182,7 +182,10 @@ export class PodOverview extends BaseComponent<IPodOverviewProps> {
                     className="fontSizeM font-size-m text-ellipsis bolt-table-link"
                     rel={"noopener noreferrer"}
                     excludeTabStop
-                    onClick={() => showImageDetails(imageId)}
+                    onClick={(e) => {
+                        e.preventDefault();
+                        showImageDetails(imageId);
+                    }}
                 >
                     {value}
                 </Link>

--- a/src/WebUI/WorkLoads/DeploymentsTable.tsx
+++ b/src/WebUI/WorkLoads/DeploymentsTable.tsx
@@ -275,11 +275,14 @@ export class DeploymentsTable extends BaseComponent<IDeploymentsTableProperties,
                     className="fontSizeM font-size-m text-ellipsis bolt-table-link"
                     rel={"noopener noreferrer"}
                     excludeTabStop
-                    onClick={() => this._onImageClick(imageId)}
+                    onClick={(e) => {
+                        e.preventDefault();
+                        this._onImageClick(imageId);
+                    }}
                 >
                     {textToRender}
                 </Link>
-            </Tooltip>
+            </Tooltip >
             : defaultColumnRenderer(textToRender);
 
         return renderTableCell(rowIndex, columnIndex, tableColumn, itemToRender, undefined, hasImageDetails ? "bolt-table-cell-content-with-link" : "");

--- a/src/WebUI/WorkLoads/OtherWorkloadsTable.tsx
+++ b/src/WebUI/WorkLoads/OtherWorkloadsTable.tsx
@@ -228,7 +228,11 @@ export class OtherWorkloads extends BaseComponent<IOtherWorkloadsProperties, IOt
                 <Link
                     className="fontSizeM font-size-m text-ellipsis bolt-table-link"
                     excludeTabStop={true}
-                    onClick={() => this._onImageClick(imageId)}>
+                    onClick={(e) => {
+                        e.preventDefault();
+                        this._onImageClick(imageId);
+                    }}
+                >
                     {imageText}
                 </Link>
             </Tooltip> :

--- a/src/WebUI/WorkLoads/WorkloadDetails.tsx
+++ b/src/WebUI/WorkLoads/WorkloadDetails.tsx
@@ -351,7 +351,10 @@ export class WorkloadDetails extends BaseComponent<IWorkloadDetailsProperties, I
                     className="fontSizeM font-size-m text-ellipsis bolt-table-link"
                     rel={"noopener noreferrer"}
                     excludeTabStop
-                    onClick={() => this._showImageDetails(imageId)}
+                    onClick={(e) => {
+                        e.preventDefault();
+                        this._showImageDetails(imageId);
+                    }}
                 >
                     {imageText}
                 </Link>


### PR DESCRIPTION
Issue- When we click on image link in a row, the onActivate handler of table row gets triggered, causing the workload details to be displayed first, after this the link.onclick gets called
Fix- If the click's target is a link element, then do not trigger the table row's click handler. We let only the image link handler be called.
