### PR TITLE
Added tooltip when image details not available

### DIFF
--- a/src/WebUI/ImageDetails/ImageDetailsStore.ts
+++ b/src/WebUI/ImageDetails/ImageDetailsStore.ts
@@ -25,12 +25,12 @@ export class ImageDetailsStore extends StoreBase {
         this._actions.setHasImageDetails.removeListener(this._setHasImageDetailsData);
     }
 
-    public hasImageDetails(imageName: string): boolean {
+    public hasImageDetails(imageName: string): boolean | undefined {
         if (this._hasImageDetails && this._hasImageDetails.hasOwnProperty(imageName)) {
             return this._hasImageDetails[imageName];
         }
 
-        return false;
+        return undefined;
     }
 
     private _setHasImageDetailsData = (payload: { [key: string]: boolean } | undefined): void => {

--- a/src/WebUI/Pods/PodOverview.tsx
+++ b/src/WebUI/Pods/PodOverview.tsx
@@ -175,7 +175,14 @@ export class PodOverview extends BaseComponent<IPodOverviewProps> {
 
     private static _renderImageCell = (rowIndex: number, columnIndex: number, tableColumn: ITableColumn<any>, tableItem: any): JSX.Element => {
         const { key, value, valueTooltipText, imageId, showImageDetails } = tableItem;
-        const hasImageDetails: boolean = StoreManager.GetStore<ImageDetailsStore>(ImageDetailsStore).hasImageDetails(imageId);
+        const imageDetailsStore = StoreManager.GetStore<ImageDetailsStore>(ImageDetailsStore);
+        let imageDetailsUnavailableTooltipText = "";
+        const hasImageDetails: boolean | undefined = imageDetailsStore.hasImageDetails(imageId);
+        // If hasImageDetails is undefined, then image details promise has not resolved, so do not set imageDetailsUnavailable tooltip
+        if (hasImageDetails === false) {
+            imageDetailsUnavailableTooltipText = localeFormat("{0} | {1}", valueTooltipText || value, Resources.ImageDetailsUnavailableText);
+        }
+        
         const itemToRender = hasImageDetails ?
             <Tooltip overflowOnly>
                 <Link
@@ -190,7 +197,7 @@ export class PodOverview extends BaseComponent<IPodOverviewProps> {
                     {value}
                 </Link>
             </Tooltip>
-            : defaultColumnRenderer(value, undefined, valueTooltipText);
+            : defaultColumnRenderer(value, undefined, imageDetailsUnavailableTooltipText);
 
         return renderTableCell(rowIndex, columnIndex, tableColumn, itemToRender, undefined, hasImageDetails ? "bolt-table-cell-content-with-link" : "");
     }

--- a/src/WebUI/Pods/PodsDetails.tsx
+++ b/src/WebUI/Pods/PodsDetails.tsx
@@ -12,7 +12,7 @@ import * as queryString from "query-string";
 import * as React from "react";
 import { IImageDetails } from "../../Contracts/Types";
 import { KubeSummary } from "../Common/KubeSummary";
-import { PodsEvents, PodsRightPanelTabsKeys } from "../Constants";
+import { PodsEvents, PodsRightPanelTabsKeys, ImageDetailsEvents } from "../Constants";
 import { ActionsCreatorManager } from "../FluxCommon/ActionsCreatorManager";
 import { StoreManager } from "../FluxCommon/StoreManager";
 import { ImageDetails } from "../ImageDetails/ImageDetails";
@@ -24,6 +24,8 @@ import { PodsActionsCreator } from "./PodsActionsCreator";
 import { PodsLeftPanel } from "./PodsLeftPanel";
 import { PodsRightPanel } from "./PodsRightPanel";
 import { PodsStore } from "./PodsStore";
+import { ImageDetailsActionsCreator } from "../ImageDetails/ImageDetailsActionsCreator";
+import { ImageDetailsStore } from "../ImageDetails/ImageDetailsStore";
 
 export interface IPodsDetailsProperties extends IVssComponentProperties {
     parentUid: string;
@@ -40,6 +42,7 @@ export interface IPodsDetailsState {
     isLoading?: boolean;
     selectedPod: V1Pod | null | undefined;
     selectedImageDetails: IImageDetails | undefined;
+    imageList?: string[];
 }
 
 export class PodsDetails extends BaseComponent<IPodsDetailsProperties, IPodsDetailsState> {
@@ -67,6 +70,9 @@ export class PodsDetails extends BaseComponent<IPodsDetailsProperties, IPodsDeta
                 }]);
             }
         };
+
+        this._imageDetailsStore = StoreManager.GetStore<ImageDetailsStore>(ImageDetailsStore);
+        this._imageDetailsStore.addListener(ImageDetailsEvents.HasImageDetailsEvent, this._setHasImageDetails);
 
         this._podsStore = StoreManager.GetStore<PodsStore>(PodsStore);
         let parentKind: string | undefined = undefined, parentName: string | undefined = undefined, filteredPods: V1Pod[] | undefined = [], selectedPod: V1Pod | undefined = undefined;
@@ -116,6 +122,7 @@ export class PodsDetails extends BaseComponent<IPodsDetailsProperties, IPodsDeta
                 const fetchedPodList = props.serviceSelector ? podsStoreState.podListByLabel[props.serviceSelector] : podsStoreState.podsList;
                 if (fetchedPodList && fetchedPodList.items) {
                     const properties = getPodProperties(fetchedPodList.items);
+                    const imageList = Utils.getImageIdsForPods(properties.pods || []);
                     // Adding breadcrumb when parent object is fetched on pod view refresh
                     notifyViewChanged(properties.parentName, properties.parentKind);
                     this.setState({
@@ -123,7 +130,8 @@ export class PodsDetails extends BaseComponent<IPodsDetailsProperties, IPodsDeta
                         parentName: properties.parentName,
                         pods: properties.pods,
                         selectedPod: properties.selectedPod,
-                        isLoading: podsStoreState.isLoading
+                        isLoading: podsStoreState.isLoading,
+                        imageList: imageList
                     });
                 }
             };
@@ -207,6 +215,21 @@ export class PodsDetails extends BaseComponent<IPodsDetailsProperties, IPodsDeta
         );
     }
 
+    public componentDidUpdate(prevProps: IPodsDetailsProperties, prevState: IPodsDetailsState) {
+        // Fetch hasImageDetailsData if we directly refresh and land on WorkloadDetails
+        const imageService = KubeSummary.getImageService();
+        if (imageService && this.state.imageList && this.state.imageList.length > 0) {
+            const hasImageDetails: boolean | undefined = this._imageDetailsStore.hasImageDetails(this.state.imageList[0]);
+            if (hasImageDetails === undefined) {
+                ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).setHasImageDetails(imageService, this.state.imageList);
+            }
+        }
+    }
+
+    public componentWillUnmount(): void {
+        this._imageDetailsStore.removeListener(ImageDetailsEvents.HasImageDetailsEvent, this._setHasImageDetails);
+    }
+
     private _onPodSelectionChange = (event: React.SyntheticEvent<HTMLElement>, selectedPod: V1Pod, selectedView: string): void => {
         let routeValues: queryString.OutputParams = queryString.parse(this._history.location.search);
         routeValues["uid"] = selectedPod.metadata.uid;
@@ -250,7 +273,12 @@ export class PodsDetails extends BaseComponent<IPodsDetailsProperties, IPodsDeta
         });
     }
 
+    private _setHasImageDetails = (): void => {
+        this.setState({});
+    }
+
     private _initialFixedSize: number = 320;
     private _history: History;
     private _podsStore: PodsStore;
+    private _imageDetailsStore: ImageDetailsStore;
 }

--- a/src/WebUI/Resources.d.ts
+++ b/src/WebUI/Resources.d.ts
@@ -94,3 +94,4 @@ export declare const TagsText: string;
 export declare const LoadingPodsSpinnerLabel: string;
 export declare const LoadingServicesSpinnerLabel: string;
 export declare const CopyExternalIp: string;
+export declare const ImageDetailsUnavailableText: string;

--- a/src/WebUI/Resources.js
+++ b/src/WebUI/Resources.js
@@ -95,4 +95,5 @@ define("Environments/Providers/Kubernetes/Resources", ["require", "exports"], fu
     exports.LoadingPodsSpinnerLabel = "Loading associated pods...";
     exports.LoadingServicesSpinnerLabel = "Loading services...";
     exports.CopyExternalIp = "Copy External IP to clipboard";
+    exports.ImageDetailsUnavailableText = "Image details available only for images built in Azure Pipelines";
 });

--- a/src/WebUI/WorkLoads/DeploymentsTable.tsx
+++ b/src/WebUI/WorkLoads/DeploymentsTable.tsx
@@ -9,7 +9,7 @@ import { Ago } from "azure-devops-ui/Ago";
 import { CardContent, CustomCard } from "azure-devops-ui/Card";
 import { ITableRow } from "azure-devops-ui/Components/Table/Table.Props";
 import { ObservableValue } from "azure-devops-ui/Core/Observable";
-import { equals, format } from "azure-devops-ui/Core/Util/String";
+import { equals, format, localeFormat } from "azure-devops-ui/Core/Util/String";
 import { CustomHeader, HeaderDescription, HeaderTitle, HeaderTitleArea, HeaderTitleRow, TitleSize } from "azure-devops-ui/Header";
 import { Link } from "azure-devops-ui/Link";
 import { ITableColumn, Table } from "azure-devops-ui/Table";
@@ -268,7 +268,13 @@ export class DeploymentsTable extends BaseComponent<IDeploymentsTableProperties,
     private _renderImageCell = (rowIndex: number, columnIndex: number, tableColumn: ITableColumn<IDeploymentReplicaSetItem>, deployment: IDeploymentReplicaSetItem): JSX.Element => {
         const textToRender: string = deployment.imageDisplayText || "";
         const imageId: string = deployment.imageId;
-        const hasImageDetails = StoreManager.GetStore<ImageDetailsStore>(ImageDetailsStore).hasImageDetails(imageId);
+        let imageDetailsUnavailableTooltipText = "";
+        const hasImageDetails: boolean | undefined = this._imageDetailsStore.hasImageDetails(imageId);
+        // If hasImageDetails is undefined, then image details promise has not resolved, so do not set imageDetailsUnavailable tooltip
+        if (hasImageDetails === false) {
+            imageDetailsUnavailableTooltipText = localeFormat("{0} | {1}",  deployment.imageTooltip || textToRender, Resources.ImageDetailsUnavailableText);
+        }
+        
         const itemToRender = hasImageDetails ?
             <Tooltip overflowOnly>
                 <Link
@@ -283,7 +289,7 @@ export class DeploymentsTable extends BaseComponent<IDeploymentsTableProperties,
                     {textToRender}
                 </Link>
             </Tooltip >
-            : defaultColumnRenderer(textToRender);
+            : defaultColumnRenderer(textToRender, "", imageDetailsUnavailableTooltipText);
 
         return renderTableCell(rowIndex, columnIndex, tableColumn, itemToRender, undefined, hasImageDetails ? "bolt-table-cell-content-with-link" : "");
     }

--- a/src/WebUI/WorkLoads/OtherWorkloadsTable.tsx
+++ b/src/WebUI/WorkLoads/OtherWorkloadsTable.tsx
@@ -9,7 +9,7 @@ import { Ago } from "azure-devops-ui/Ago";
 import { CardContent, CustomCard } from "azure-devops-ui/Card";
 import { ITableRow } from "azure-devops-ui/Components/Table/Table.Props";
 import { ObservableValue } from "azure-devops-ui/Core/Observable";
-import { equals } from "azure-devops-ui/Core/Util/String";
+import { equals, localeFormat } from "azure-devops-ui/Core/Util/String";
 import { CustomHeader, HeaderTitle, HeaderTitleArea, HeaderTitleRow, TitleSize } from "azure-devops-ui/Header";
 import { Link } from "azure-devops-ui/Link";
 import { Statuses } from "azure-devops-ui/Status";
@@ -221,8 +221,13 @@ export class OtherWorkloads extends BaseComponent<IOtherWorkloadsProperties, IOt
     private _renderImageCell = (rowIndex: number, columnIndex: number, tableColumn: ITableColumn<ISetWorkloadTypeItem>, workload: ISetWorkloadTypeItem): JSX.Element => {
         const imageId = workload.imageId;
         const imageText = workload.imageDisplayText || "";
-        // ToDo :: Revisit link paddings
-        const hasImageDetails = StoreManager.GetStore<ImageDetailsStore>(ImageDetailsStore).hasImageDetails(imageId);
+        let imageDetailsUnavailableTooltipText = "";
+        const hasImageDetails: boolean | undefined = this._imageDetailsStore.hasImageDetails(imageId);
+        // If hasImageDetails is undefined, then image details promise has not resolved, so do not set imageDetailsUnavailable tooltip
+        if (hasImageDetails === false) {
+            imageDetailsUnavailableTooltipText = localeFormat("{0} | {1}",  workload.imageTooltip || imageText, Resources.ImageDetailsUnavailableText);
+        }
+        
         const itemToRender = hasImageDetails ?
             <Tooltip overflowOnly={true}>
                 <Link
@@ -235,10 +240,8 @@ export class OtherWorkloads extends BaseComponent<IOtherWorkloadsProperties, IOt
                 >
                     {imageText}
                 </Link>
-            </Tooltip> :
-            <Tooltip text={imageText} overflowOnly>
-                {defaultColumnRenderer(imageText || "")}
-            </Tooltip>;
+            </Tooltip> 
+            : defaultColumnRenderer(imageText, "", imageDetailsUnavailableTooltipText);
 
         return renderTableCell(rowIndex, columnIndex, tableColumn, itemToRender, undefined, "bolt-table-cell-content-with-link");
     }


### PR DESCRIPTION
Showing image name tooltip according to following algorithm -

Before promise for image details is resolved-
show tooltip only when element does not fit in visible area, otherwise do not show any tooltip.

Once promise is done,
if we have image details, we will show the link. Tooltip is shown only when the element does not fit.
if image details not available then we show text like "image name | Image details available only for images built in Azure Pipelines"

Also added handling for fetching hasImageDetails when we directly land on workloadDetails or PodDetails.