### PR TITLE
Using SummaryCard instead of Table for image and Pod details

### DIFF
--- a/src/WebUI/Common/KubeSummary.scss
+++ b/src/WebUI/Common/KubeSummary.scss
@@ -1,15 +1,36 @@
 .kubernetes-container {
     // cards have margins
-    .k8s-card-padding+.k8s-card-padding {
+    .k8s-card-padding + .k8s-card-padding {
         margin-top: 16px;
     }
-
     /*Css to adjust the alignment of text between picklist and text search. Revisit when we move from picklist to dropdown (fabric-free)*/
-    .keyword-search.bolt-text-field{
+    .keyword-search.bolt-text-field {
         padding-bottom: 8px;
     }
 
     .loading-pods {
         height: 200px;
+    }
+
+    .details-card-content {
+        flex-wrap: wrap;
+        width: 100%;
+
+        .details-card-row-size {
+            padding-top: 6px;
+            padding-bottom: 6px;
+            position: relative;
+        }
+
+        .details-card-info-field-size {
+            width: 96px;
+            min-width: 96px;
+        }
+
+        .details-card-value-field-size {
+            position: absolute;
+            width: calc(100% - 136px); // 136px = label width 96px + left padding of card 20px + gap required between label and value 20px
+            margin-left: 136px;
+        }
     }
 }

--- a/src/WebUI/ImageDetails/ImageDetails.scss
+++ b/src/WebUI/ImageDetails/ImageDetails.scss
@@ -26,13 +26,7 @@
     cursor: pointer;
 }
 
-// todo :: once summary card is available we should remove this
-.image-details-key .image-o-k-col-content,
-.image-details-value .image-o-v-col-content {
-    padding-top: 5px;
-    padding-bottom: 5px;
-}
-
 .image-details-card .image-full-details-table {
-    padding-bottom: 16px;
+    padding-bottom: 20px;
+    padding-top: 14px;
 }

--- a/src/WebUI/ImageDetails/ImageDetails.tsx
+++ b/src/WebUI/ImageDetails/ImageDetails.tsx
@@ -86,26 +86,6 @@ export class ImageDetails extends BaseComponent<IImageDetailsProperties, IImageD
 
     private _getImageDetails(): JSX.Element | null {
         const imageDetails = this.props.imageDetails;
-        const columns: ITableColumn<any>[] = [
-            {
-                id: "key",
-                name: "key",
-                width: new ObservableValue(150),
-                className: "image-details-key",
-                columnStyle: TableColumnStyle.Tertiary,
-                renderCell: ImageDetails._renderKeyCell
-            },
-            {
-                id: "value",
-                name: "value",
-                width: -100,
-                className: "image-details-value",
-                minWidth: 400,
-                renderCell: ImageDetails._renderValueCell
-            }
-        ];
-
-        const tableItems = this._getImageDetailsRowsData(imageDetails);
 
         return (
             <CustomCard className="image-details-card k8s-card-padding flex-grow bolt-card-no-vertical-padding">
@@ -118,23 +98,14 @@ export class ImageDetails extends BaseComponent<IImageDetailsProperties, IImageD
                         </HeaderTitleRow>
                     </HeaderTitleArea>
                 </CustomHeader>
-                <CardContent className="image-full-details-table" contentPadding={false}>
-                    <Table
-                        className="image-details-table"
-                        id={format("image-details-{0}", imageDetails.hash)}
-                        showHeader={false}
-                        showLines={false}
-                        singleClickActivation={false}
-                        itemProvider={tableItems}
-                        pageSize={tableItems.length}
-                        columns={columns}
-                    />
+                <CardContent className="image-full-details-table" contentPadding={true}>
+                    {this._getCardContent()}
                 </CardContent>
             </CustomCard>
         );
     }
 
-    private _getImageDetailsRowsData(imageDetails: IImageDetails): ArrayItemProvider<any> {
+    private _getImageDetailsRowsData(imageDetails: IImageDetails): any[] {
         let imageDetailsRows: any[] = [];
         const digest: string = imageDetails.hash || "";
         const imageType: string = imageDetails.imageType || "";
@@ -152,51 +123,44 @@ export class ImageDetails extends BaseComponent<IImageDetailsProperties, IImageD
         imageSize && imageDetailsRows.push({ key: Resources.ImageSizeText, value: imageSize });
         labels && labels.length > 0 && imageDetailsRows.push({ key: Resources.LabelsText, value: labels });
 
-        return new ArrayItemProvider<any>(imageDetailsRows);
+        return imageDetailsRows;
     }
 
-    private static _renderValueCell(
-        rowIndex: number,
-        columnIndex: number,
-        tableColumn: ITableColumn<any>,
-        tableItem: any): JSX.Element {
+    private static _renderValueCell = (tableItem: any): JSX.Element => {
         const { key, value } = tableItem;
-        let props: any = {};
-        const contentClassName = "image-o-v-col-content";
         switch (key) {
             case Resources.LabelsText:
             case Resources.TagsText:
-                props = {
-                    columnIndex: columnIndex,
-                    children:
-                    <Tags items={value} />,
-                    tableColumn: tableColumn,
-                    contentClassName: css(contentClassName, "image-labelgroups")
-                };
-
-                return renderSimpleTableCell(props);
+                return (
+                    <div className="text-ellipsis details-card-value-field-size">
+                        <Tags items={value} className="body-s" />
+                    </div>
+                );
 
             default:
-                const itemToRender = <span className="image-details-value-cell">{value}</span>;
-                return renderTableCell(rowIndex, columnIndex, tableColumn, itemToRender, undefined, contentClassName);
+                const itemToRender = defaultColumnRenderer(value);
+                return (
+                    <div className="text-ellipsis details-card-value-field-size">
+                        {itemToRender}
+                    </div>
+                );
         }
     }
 
-    private static _renderKeyCell(
-        rowIndex: number,
-        columnIndex: number,
-        tableColumn: ITableColumn<any>,
-        tableItem: any): JSX.Element {
-        const { key } = tableItem;
-        const contentClassName = "image-o-k-col-content";
-
-        const itemToRender = (
-            <Tooltip text={key} overflowOnly>
-                <span className={css("text-ellipsis")}>{key}</span>
-            </Tooltip>
+    private _getCardContent = (): JSX.Element => {
+        const items = this._getImageDetailsRowsData(this.props.imageDetails);
+        return (
+            <div className="flex-column details-card-content">
+                {items.map((item, index) => (
+                    <div className="flex-row details-card-row-size body-m" key={index}>
+                        <div className="text-ellipsis secondary-text details-card-info-field-size">
+                            {item.key}
+                        </div>
+                        {ImageDetails._renderValueCell(item)}
+                    </div>))
+                }
+            </div>
         );
-
-        return renderTableCell(rowIndex, columnIndex, tableColumn, itemToRender, undefined, contentClassName);
     }
 
     private _getImageLayers(): JSX.Element | null {
@@ -232,7 +196,7 @@ export class ImageDetails extends BaseComponent<IImageDetailsProperties, IImageD
     }
 
 
-    private _sortByCreatedDate(layerInfo : IImageLayer[]): IImageLayer[] {
+    private _sortByCreatedDate(layerInfo: IImageLayer[]): IImageLayer[] {
         layerInfo.sort((a: IImageLayer, b: IImageLayer) => {
             // Most recent layer to be shown first
             return this.getTime(b.createdOn) - this.getTime(a.createdOn);
@@ -293,7 +257,7 @@ export class ImageDetails extends BaseComponent<IImageDetailsProperties, IImageD
     private static _renderLayersSizeCell(rowIndex: number, columnIndex: number, tableColumn: ITableColumn<IImageLayer>, imageLayer: IImageLayer): JSX.Element {
         // Currently size data is not present in imageLayer
         let textToRender = imageLayer.size;
-        if(!textToRender || textToRender.toUpperCase() === "0B"){
+        if (!textToRender || textToRender.toUpperCase() === "0B") {
             textToRender = "-";
         }
 

--- a/src/WebUI/Pods/PodOverview.scss
+++ b/src/WebUI/Pods/PodOverview.scss
@@ -6,5 +6,6 @@
 }
 
 .pod-overview-card .pod-full-details-table {
-    padding-bottom: 16px;
+    padding-bottom: 20px;
+    padding-top: 14px;
 }

--- a/src/WebUI/Pods/PodsActionsCreator.ts
+++ b/src/WebUI/Pods/PodsActionsCreator.ts
@@ -3,7 +3,7 @@
     Licensed under the MIT license.
 */
 
-import { V1Pod, V1PodList } from "@kubernetes/client-node";
+import { V1Pod, V1PodList, V1ListMeta } from "@kubernetes/client-node";
 import { IKubeService } from "../../Contracts/Contracts";
 import { ActionCreatorBase } from "../FluxCommon/Actions";
 import { ActionsHubManager } from "../FluxCommon/ActionsHubManager";
@@ -18,16 +18,29 @@ export class PodsActionsCreator extends ActionCreatorBase {
         this._actions = ActionsHubManager.GetActionsHub<PodsActions>(PodsActions);
     }
 
-    public getPods(kubeService: IKubeService, labelSelector?: string): void {
-        kubeService && kubeService.getPods(labelSelector || undefined).then(podList => {
-            this._extendPodMetadataInList(podList);
-            if (labelSelector) {
-                this._actions.podsFetchedByLabel.invoke({ podsList: podList, labelSelector: labelSelector, isLoading: false });
-            }
-            else {
-                this._actions.podsFetched.invoke({ podsList: podList, isLoading: false });
-            }
-        });
+    public getPods(kubeService: IKubeService, labelSelector?: string, fetchByLabel: boolean = false): void {
+        if (fetchByLabel && !labelSelector) {
+            // For service's associated pods, fetchByLabel is true; In this scenario if no label selector is supplied, it implies zero pods
+            const podList: V1PodList = {
+                apiVersion: "",
+                items: [],
+                kind: "",
+                metadata: {} as V1ListMeta
+            };
+            // Calling action inside timeout to ensure the action listener is initialized in the ServiceDetails
+            setTimeout(() => this._actions.podsFetchedByLabel.invoke({ podsList: podList, labelSelector: "", isLoading: false }));
+        }
+        else {
+            kubeService && kubeService.getPods(labelSelector || undefined).then(podList => {
+                this._extendPodMetadataInList(podList);
+                if (labelSelector) {
+                    this._actions.podsFetchedByLabel.invoke({ podsList: podList, labelSelector: labelSelector, isLoading: false });
+                }
+                else {
+                    this._actions.podsFetched.invoke({ podsList: podList, isLoading: false });
+                }
+            });
+        }
     }
 
     // getPod() will provide apiVersion for pod also, should we call?

--- a/src/WebUI/Pods/PodsDetails.tsx
+++ b/src/WebUI/Pods/PodsDetails.tsx
@@ -138,7 +138,7 @@ export class PodsDetails extends BaseComponent<IPodsDetailsProperties, IPodsDeta
 
             this._podsStore.addListener(storeEventName, podsFetchHandler);
             if (props.serviceSelector) {
-                podsActionCreator.getPods(KubeSummary.getKubeService(), props.serviceSelector);
+                podsActionCreator.getPods(KubeSummary.getKubeService(), props.serviceSelector, true);
             }
             else {
                 podsActionCreator.getPods(KubeSummary.getKubeService());

--- a/src/WebUI/Services/ServiceDetails.tsx
+++ b/src/WebUI/Services/ServiceDetails.tsx
@@ -77,7 +77,7 @@ export class ServiceDetails extends BaseComponent<IServiceDetailsProperties, ISe
         const fetchServiceDetails = (svc: V1Service) => {
             // service currently only supports equals with "and" operator. The generator generates that condition.
             const labelSelector: string = Utils.generateEqualsConditionLabelSelector(svc && svc.spec && svc.spec.selector || {});
-            this._podsActionsCreator.getPods(KubeSummary.getKubeService(), labelSelector);
+            this._podsActionsCreator.getPods(KubeSummary.getKubeService(), labelSelector, true);
         };
 
         if (!props.service) {


### PR DESCRIPTION
1. Replaced table with summary card in pod and image details.
2. Handling Zero pods scenario for services.
Test-pod: http://nidabas-desk:8096/summary?namespace=default
