### PR TITLE
History service being used in SelectionActionCreator is stale

### DIFF
--- a/src/WebUI/Selection/SelectionActionCreator.ts
+++ b/src/WebUI/Selection/SelectionActionCreator.ts
@@ -16,12 +16,14 @@ export class SelectionActionsCreator extends ActionCreatorBase {
     }
 
     public initialize(instanceId?: string): void {
-        this._historyService = createBrowserHistory();
         this._actions = ActionsHubManager.GetActionsHub<SelectionActions>(SelectionActions);
     }
 
     public selectItem(payload: ISelectionPayload): void {
-        let routeValues: queryString.OutputParams = queryString.parse(this._historyService.location.search);
+        // Create history service fresh here, because we need the fresh url location
+        // Unlike components, action creators are not re initialized on view mount
+        const historyService = createBrowserHistory();
+        let routeValues: queryString.OutputParams = queryString.parse(historyService.location.search);
         routeValues["type"] = payload.selectedItemType;
         routeValues["uid"] = payload.itemUID;
 
@@ -46,8 +48,8 @@ export class SelectionActionsCreator extends ActionCreatorBase {
             });
         }
 
-        this._historyService.push({
-            pathname: this._historyService.location.pathname,
+        historyService.push({
+            pathname: historyService.location.pathname,
             search: queryString.stringify(routeValues)
         });
 
@@ -55,5 +57,4 @@ export class SelectionActionsCreator extends ActionCreatorBase {
     }
 
     private _actions: SelectionActions;
-    private _historyService: History;
 }


### PR DESCRIPTION
Since action creators are singleton objects, they don't get re-initialized on component mounts
Components are reinitialized every time the component is mounted.

This is why we can't use a ready made instance object in the action creator.