### PR TITLE
Fix for scroll bar in pod-logs view

### DIFF
--- a/src/WebUI/Common/ContentReader.tsx
+++ b/src/WebUI/Common/ContentReader.tsx
@@ -81,7 +81,11 @@ export class ContentReader extends React.Component<IReaderProps> {
 
     private _disposeEditor(): void {
         if (this._editor) {
-            this._editor.dispose();
+            try {
+                this._editor.dispose();
+            }
+            catch (e) { }
+
             this._editor = undefined;
         }
     }

--- a/src/WebUI/Pods/PodLog.scss
+++ b/src/WebUI/Pods/PodLog.scss
@@ -1,3 +1,0 @@
-.k8s-pod-log {
-    margin-bottom: 16px;
-}

--- a/src/WebUI/Pods/PodLog.scss
+++ b/src/WebUI/Pods/PodLog.scss
@@ -1,0 +1,3 @@
+.k8s-pod-log {
+    margin-bottom: 16px;
+}

--- a/src/WebUI/Pods/PodLog.tsx
+++ b/src/WebUI/Pods/PodLog.tsx
@@ -42,24 +42,7 @@ export class PodLog extends React.Component<IPodLogProps, IPodLogState> {
         );
     }
 
-    public componentWillUnmount(): void {
-        if (this._heightCssElement && document && document.head) {
-            document.head.removeChild(this._heightCssElement);
-            this._heightCssElement = undefined;
-        }
-    }
-
     public componentDidMount(): void {
-        if (!this._heightCssElement) {
-            this._heightCssElement = document.createElement("style");
-            this._heightCssElement.type = "text/css";
-            if (document && document.head) {
-                document.head.appendChild(this._heightCssElement);
-            }
-        }
-
-        this._heightCssElement.innerText = ".kubernetes-container .pod-overview-full-size { height: unset; min-height: 100%; }";
-
         const service = KubeSummary.getKubeService();
         const podName = this.props.pod.metadata.name;
         const spec = this.props.pod.spec || undefined;
@@ -79,6 +62,4 @@ export class PodLog extends React.Component<IPodLogProps, IPodLogState> {
             });
         });
     }
-
-    private _heightCssElement: HTMLStyleElement | undefined;
 }

--- a/src/WebUI/Pods/PodLog.tsx
+++ b/src/WebUI/Pods/PodLog.tsx
@@ -9,7 +9,6 @@ import * as React from "react";
 import { KubeSummary } from "../Common/KubeSummary";
 import * as Resources from "../Resources";
 import { PodContentReader } from "./PodContentReader";
-import "./PodLog.scss";
 import { IPodRightPanelProps } from "./PodsRightPanel";
 
 export interface IPodLogProps extends IPodRightPanelProps {

--- a/src/WebUI/Pods/PodLog.tsx
+++ b/src/WebUI/Pods/PodLog.tsx
@@ -42,7 +42,24 @@ export class PodLog extends React.Component<IPodLogProps, IPodLogState> {
         );
     }
 
+    public componentWillUnmount(): void {
+        if (this._heightCssElement && document && document.head) {
+            document.head.removeChild(this._heightCssElement);
+            this._heightCssElement = undefined;
+        }
+    }
+
     public componentDidMount(): void {
+        if (!this._heightCssElement) {
+            this._heightCssElement = document.createElement("style");
+            this._heightCssElement.type = "text/css";
+            if (document && document.head) {
+                document.head.appendChild(this._heightCssElement);
+            }
+        }
+
+        this._heightCssElement.innerText = ".kubernetes-container .pod-overview-full-size { height: unset; min-height: 100%; }";
+
         const service = KubeSummary.getKubeService();
         const podName = this.props.pod.metadata.name;
         const spec = this.props.pod.spec || undefined;
@@ -62,4 +79,6 @@ export class PodLog extends React.Component<IPodLogProps, IPodLogState> {
             });
         });
     }
+
+    private _heightCssElement: HTMLStyleElement | undefined;
 }

--- a/src/WebUI/Pods/PodLog.tsx
+++ b/src/WebUI/Pods/PodLog.tsx
@@ -9,6 +9,7 @@ import * as React from "react";
 import { KubeSummary } from "../Common/KubeSummary";
 import * as Resources from "../Resources";
 import { PodContentReader } from "./PodContentReader";
+import "./PodLog.scss";
 import { IPodRightPanelProps } from "./PodsRightPanel";
 
 export interface IPodLogProps extends IPodRightPanelProps {
@@ -31,11 +32,13 @@ export class PodLog extends React.Component<IPodLogProps, IPodLogState> {
         return (
             <PodContentReader
                 key={this.state.uid}
-                className="pod-log"
-                contentClassName="pod-log-content"
+                className="k8s-pod-log"
+                contentClassName="k8s-pod-log-content"
                 options={{
                     theme: "vs-dark",
-                    language: "text/plain"
+                    language: "text/plain",
+                    wordWrap: "on",
+                    wrappingIndent: "same"
                 }}
                 text={this.state.logContent || ""}
             />

--- a/src/WebUI/Pods/PodsRightPanel.scss
+++ b/src/WebUI/Pods/PodsRightPanel.scss
@@ -2,6 +2,10 @@
     height: 100%;
 }
 
+.pod-overview-content-full-size {
+    min-height: 100%;
+}
+
 .pod-overview-error-height {
-    height: calc(100% - 64px);
+    min-height: calc(100% - 64px);
 }

--- a/src/WebUI/Pods/PodsRightPanel.tsx
+++ b/src/WebUI/Pods/PodsRightPanel.tsx
@@ -209,7 +209,7 @@ export class PodsRightPanel extends React.Component<IPodRightPanelProps, IPodsRi
             return "";
         }
 
-        return css("full-size", hasMessageCard ? "pod-overview-error-height" : "pod-overview-full-size");
+        return css("full-size", hasMessageCard ? "pod-overview-error-height" : "pod-overview-content-full-size");
     }
 
     private _hideImageDetails = () => {

--- a/src/WebUI/WorkLoads/WorkloadDetails.tsx
+++ b/src/WebUI/WorkLoads/WorkloadDetails.tsx
@@ -198,7 +198,7 @@ export class WorkloadDetails extends React.Component<IWorkloadDetailsProperties,
     }
 
     public componentWillUnmount(): void {
-        this._podsStore.removeChangedListener(this._onPodsUpdated);
+        this._podsStore.removeListener(PodsEvents.PodsFetchedEvent, this._onPodsUpdated);
         this._imageDetailsStore.removeListener(ImageDetailsEvents.HasImageDetailsEvent, this._setHasImageDetails);
     }
 


### PR DESCRIPTION
Tested on tfat deployment - http://nidabas-desk/DefaultCollection/p1/_environments/1/providers/kubernetes/1?parentUid=b5187188-495e-11e9-96d5-96c741883af0&type=pod-details&uid=250c2f76-513b-11e9-8065-4e0ced212508&view=pod-logs