### PR TITLE
Adjusted the spacing between header and content as per figma

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ jobs:
   timeoutInMinutes: 20
   cancelTimeoutInMinutes: 2
   pool:
-    name: 'Hosted macOS'
+    name: 'Hosted'
 
   steps:
   - task: NodeTool@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ jobs:
   timeoutInMinutes: 20
   cancelTimeoutInMinutes: 2
   pool:
-    name: 'Hosted'
+    name: 'Hosted Windows 2019 with VS2019'
 
   steps:
   - task: NodeTool@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ jobs:
   timeoutInMinutes: 20
   cancelTimeoutInMinutes: 2
   pool:
-    name: 'Hosted VS2017'
+    name: 'Hosted macOS'
 
   steps:
   - task: NodeTool@0

--- a/src/WebUI/Common/KubeSummary.scss
+++ b/src/WebUI/Common/KubeSummary.scss
@@ -19,7 +19,10 @@
         width: 100%;
 
         .details-card-row-size {
-            padding-top: 6px;
+            &:not(.first-row) {
+                padding-top: 6px;
+            }
+
             padding-bottom: 6px;
             position: relative;
 

--- a/src/WebUI/ImageDetails/ImageDetails.scss
+++ b/src/WebUI/ImageDetails/ImageDetails.scss
@@ -27,6 +27,9 @@
 }
 
 .image-details-card .image-full-details-table {
-    padding-bottom: 20px;
-    padding-top: 14px;
+    padding-bottom: 16px;
+}
+
+.image-layers-card .bolt-header-default {
+    padding-bottom: 12px;
 }

--- a/src/WebUI/ImageDetails/ImageDetails.tsx
+++ b/src/WebUI/ImageDetails/ImageDetails.tsx
@@ -23,6 +23,7 @@ import { getRunDetailsText } from "../RunDetails";
 import { IVssComponentProperties } from "../Types";
 import { Utils } from "../Utils";
 import "./ImageDetails.scss";
+import { css } from "azure-devops-ui/Util";
 
 export interface IImageDetailsProperties extends IVssComponentProperties {
     imageDetails: IImageDetails;
@@ -141,10 +142,12 @@ export class ImageDetails extends React.Component<IImageDetailsProperties, IImag
 
     private _getCardContent = (): JSX.Element => {
         const items = this._getImageDetailsRowsData(this.props.imageDetails);
+        const rowClassNames = "flex-row details-card-row-size body-m";
         return (
             <div className="flex-column details-card-content">
                 {items.map((item, index) => (
-                    <div className="flex-row details-card-row-size body-m" key={index}>
+                     <div className={index === 0 ? css(rowClassNames, "first-row") : rowClassNames} key={index}>
+
                         <div className="text-ellipsis secondary-text details-card-info-field-size">
                             {item.key}
                         </div>

--- a/src/WebUI/Pods/PodOverview.tsx
+++ b/src/WebUI/Pods/PodOverview.tsx
@@ -117,7 +117,7 @@ export class PodOverview extends React.Component<IPodOverviewProps> {
                 {items.map((item, index) =>
                     (item.key === Resources.ImageText)
                         ? (
-                            <div className={css("pod-image-data", rowClassNames)} key={index}>
+                            <div className={index === 0 ? css("pod-image-data", rowClassNames, "first-row") : css("pod-image-data", rowClassNames)} key={index}>
                                 <div className={css("pod-image-key", keyClassNames)}>
                                     {item.key}
                                 </div>
@@ -125,7 +125,7 @@ export class PodOverview extends React.Component<IPodOverviewProps> {
                             </div>
                         )
                         : (
-                            <div className={rowClassNames} key={index}>
+                            <div className={index === 0 ? css(rowClassNames, "first-row") : rowClassNames} key={index}>
                                 <div className={keyClassNames}>
                                     {item.key}
                                 </div>

--- a/src/WebUI/Pods/PodsTable.scss
+++ b/src/WebUI/Pods/PodsTable.scss
@@ -1,0 +1,3 @@
+.pods-associated .bolt-header-default {
+    padding-bottom: 12px;
+}

--- a/src/WebUI/Pods/PodsTable.tsx
+++ b/src/WebUI/Pods/PodsTable.tsx
@@ -26,6 +26,7 @@ import { SelectionActionsCreator } from "../Selection/SelectionActionCreator";
 import { ISelectionPayload, SelectionActions } from "../Selection/SelectionActions";
 import { IVssComponentProperties } from "../Types";
 import { Utils } from "../Utils";
+import "./PodsTable.scss";
 
 const podNameKey: string = "pl-name-key";
 const podWorkloadsKey: string = "pl-wrkld-key";

--- a/src/WebUI/WorkLoads/WorkloadsPivot.scss
+++ b/src/WebUI/WorkLoads/WorkloadsPivot.scss
@@ -1,0 +1,3 @@
+.workloads-pivot-data .bolt-header-default {
+    padding-bottom: 12px;
+}

--- a/src/WebUI/WorkLoads/WorkloadsPivot.tsx
+++ b/src/WebUI/WorkLoads/WorkloadsPivot.tsx
@@ -27,6 +27,7 @@ import { OtherWorkloads } from "../Workloads/OtherWorkloadsTable";
 import { WorkloadsActionsCreator } from "./WorkloadsActionsCreator";
 import { WorkloadsFilterBar } from "./WorkloadsFilterBar";
 import { WorkloadsStore } from "./WorkloadsStore";
+import "./WorkloadsPivot.scss";
 
 export interface IWorkloadsPivotState {
     workloadResourceSize: number;


### PR DESCRIPTION
1. Reduced the bolt-table-header-default padding bottom to 12 px from 16 px as per figma - (in Workloads Pivot, Associated Pods table, and Image Layers card)
2. In Pod-Overview and Image Details card, the spacing between header and first row is 20 px in figma, in current UI it was 26px (4px header text padding, 16 px header bottom padding + 6 px details-row padding top) => Removed details-row padding top for first row.
3. In ImageDetails card same changes as in point 2 above

Pod for seeing the changes - http://nidabas-desk:8096/summary?namespace=default