### PR TITLE
ImageDetails Tags,Labels,Size update

### DIFF
--- a/src/WebUI/Common/Tags.tsx
+++ b/src/WebUI/Common/Tags.tsx
@@ -13,16 +13,18 @@ import React = require("react");
 
 export interface ITagsProperties extends IVssComponentProperties {
     items: { [key: string]: string };
+    showOnlyValues?: boolean;
 }
 
 export class Tags extends React.Component<ITagsProperties> {
     darkColor: any;
+
     public render(): React.ReactNode {
+        const items = this.props.showOnlyValues ? this.props.items : Utils.getPillTags(this.props.items);
         return (
             <PillGroup className={css(this.props.className, "k8s-tags", "flex-row")} overflow={PillGroupOverflow.fade}>
                 {
-                    Utils.getPillTags(this.props.items)
-                        .map((tagText, index) => <Pill key={index} className="k8s-tag-pill" size={PillSize.compact}>{tagText}</Pill>)
+                    items && (items as string[]).map((tagText, index) => <Pill key={index} className="k8s-tag-pill" size={PillSize.compact}>{tagText}</Pill>)
                 }
             </PillGroup>
         );

--- a/src/WebUI/ImageDetails/ImageDetails.tsx
+++ b/src/WebUI/ImageDetails/ImageDetails.tsx
@@ -142,7 +142,7 @@ export class ImageDetails extends React.Component<IImageDetailsProperties, IImag
             case Resources.TagsText:
                 return (
                     <div className="text-ellipsis details-card-value-field-size">
-                        <Tags items={value} className="body-s" />
+                        <Tags items={value} className="body-s" showOnlyValues={true} />
                     </div>
                 );
 

--- a/src/WebUI/Utils.ts
+++ b/src/WebUI/Utils.ts
@@ -286,8 +286,7 @@ export class Utils {
     }
 
     public static extractDisplayImageName(imageId: string): string {
-        let imageName = Utils.getImageResourceUrlParameter(imageId, matchPatternForImageName);
-        return Utils.appendDefaultTagToImageName(imageName);
+        return Utils.getImageResourceUrlParameter(imageId, matchPatternForImageName);
     }
 
     public static appendDefaultTagToImageName(imageName: string): string {


### PR DESCRIPTION
1. Removed default tag from image header, as it is already present in details card.
2. Handling tags and labels for images- Image tags are not in key-val pair format, they are mostly just an integer; Image labels are already present as key-value pair
New UI-
![image](https://user-images.githubusercontent.com/12389221/57508004-f305cc00-731d-11e9-9efa-e49a5ef8a6c0.png)
Old version-
![image](https://user-images.githubusercontent.com/12389221/57508053-16c91200-731e-11e9-8063-593251c5354c.png)
Pod for testing- http://nidabas-desk/DefaultCollection/p1/_serviceEndpoints/ed2bc004-c695-4955-b8b5-b4488b89cad8/kubernetesSummary?namespace=default