### PR TITLE
Store image details to avoid making repetitive calls to service

### DIFF
--- a/src/WebUI/Constants.ts
+++ b/src/WebUI/Constants.ts
@@ -41,7 +41,7 @@ export namespace PodsEvents {
 
 export namespace ImageDetailsEvents {
     export const HasImageDetailsEvent: string = "HAS_IMAGE_DETAILS_EVENT";
-    export const GetImageDetailsEvent: string = "GET_IMAGE_DETAILS_EVENT";
+    export const SetImageDetailsEvent: string = "SET_IMAGE_DETAILS_EVENT";
 }
 
 export namespace HyperLinks {

--- a/src/WebUI/ImageDetails/ImageDetailsActions.ts
+++ b/src/WebUI/ImageDetails/ImageDetailsActions.ts
@@ -13,11 +13,17 @@ export class ImageDetailsActions extends ActionsHubBase {
 
     public initialize(): void {
         this._setHasImageDetails = new Action<{ [key: string]: boolean } | undefined>();
+        this._setImageDetails = new Action<IImageDetails>();
     }
 
     public get setHasImageDetails(): Action<{ [key: string]: boolean } | undefined> {
         return this._setHasImageDetails;
     }
 
+    public get setImageDetails(): Action<IImageDetails> {
+        return this._setImageDetails;
+    }
+
     private _setHasImageDetails: Action<{ [key: string]: boolean } | undefined>;
+    private _setImageDetails: Action<IImageDetails>;
 }

--- a/src/WebUI/ImageDetails/ImageDetailsActionsCreator.ts
+++ b/src/WebUI/ImageDetails/ImageDetailsActionsCreator.ts
@@ -27,6 +27,10 @@ export class ImageDetailsActionsCreator extends ActionCreatorBase {
         });
     }
 
+    public setImageDetails(imageDetails: IImageDetails): void {
+        this._actions.setImageDetails.invoke(imageDetails);
+    }
+
     private _actions: ImageDetailsActions;
 }
 

--- a/src/WebUI/ImageDetails/ImageDetailsActionsCreator.ts
+++ b/src/WebUI/ImageDetails/ImageDetailsActionsCreator.ts
@@ -5,10 +5,13 @@
 
 import { ActionCreatorBase, Action } from "../FluxCommon/Actions";
 import { ActionsHubManager } from "../FluxCommon/ActionsHubManager";
+import { StoreManager } from "../FluxCommon/StoreManager";
 import { IImageService } from "../../Contracts/Contracts";
 import { IImageDetails } from "../../Contracts/Types";
 import { ImageDetailsActions } from "./ImageDetailsActions";
+import { ImageDetailsStore } from "./ImageDetailsStore";
 import { ImageDetailsEvents } from "../Constants";
+import { KubeFactory } from "../KubeFactory";
 
 export class ImageDetailsActionsCreator extends ActionCreatorBase {
     public static getKey(): string {
@@ -17,6 +20,7 @@ export class ImageDetailsActionsCreator extends ActionCreatorBase {
 
     public initialize(instanceId?: string): void {
         this._actions = ActionsHubManager.GetActionsHub<ImageDetailsActions>(ImageDetailsActions);
+        this._imageDetailsStore = StoreManager.GetStore<ImageDetailsStore>(ImageDetailsStore);
     }
 
     public setHasImageDetails(imageService: IImageService, listImages: string[]): void {
@@ -27,10 +31,23 @@ export class ImageDetailsActionsCreator extends ActionCreatorBase {
         });
     }
 
-    public setImageDetails(imageDetails: IImageDetails): void {
-        this._actions.setImageDetails.invoke(imageDetails);
+    public getImageDetails(imageId: string, showImageDetailsAction: (imageDetails: IImageDetails) => void) {
+        let imageDetails: IImageDetails | undefined = this._imageDetailsStore.getImageDetails(imageId);
+        if (imageDetails) {
+            showImageDetailsAction(imageDetails);
+        }
+        else {
+            const imageService = KubeFactory.getImageService();
+            imageService && imageService.getImageDetails(imageId).then(fetchedImageDetails => {
+                if (fetchedImageDetails) {
+                    this._actions.setImageDetails.invoke(fetchedImageDetails);
+                    showImageDetailsAction(fetchedImageDetails);
+                }
+            });
+        }
     }
 
     private _actions: ImageDetailsActions;
+    private _imageDetailsStore: ImageDetailsStore;
 }
 

--- a/src/WebUI/ImageDetails/ImageDetailsStore.ts
+++ b/src/WebUI/ImageDetails/ImageDetailsStore.ts
@@ -28,19 +28,11 @@ export class ImageDetailsStore extends StoreBase {
     }
 
     public hasImageDetails(imageName: string): boolean | undefined {
-        if (this._hasImageDetails && this._hasImageDetails.hasOwnProperty(imageName)) {
-            return this._hasImageDetails[imageName];
-        }
-
-        return undefined;
+        return this._hasImageDetails[imageName];
     }
 
     public getImageDetails(imageName: string): IImageDetails | undefined {
-        if (this._imageDetails && this._imageDetails.hasOwnProperty(imageName)) {
-            return this._imageDetails[imageName];
-        }
-
-        return undefined;
+        return this._imageDetails[imageName];
     }
 
     private _setHasImageDetailsData = (payload: { [key: string]: boolean } | undefined): void => {

--- a/src/WebUI/ImageDetails/ImageDetailsStore.ts
+++ b/src/WebUI/ImageDetails/ImageDetailsStore.ts
@@ -19,10 +19,12 @@ export class ImageDetailsStore extends StoreBase {
 
         this._actions = ActionsHubManager.GetActionsHub<ImageDetailsActions>(ImageDetailsActions);
         this._actions.setHasImageDetails.addListener(this._setHasImageDetailsData);
+        this._actions.setImageDetails.addListener(this._setImageDetailsData);
     }
 
     public disposeInternal(): void {
         this._actions.setHasImageDetails.removeListener(this._setHasImageDetailsData);
+        this._actions.setImageDetails.removeListener(this._setImageDetailsData);
     }
 
     public hasImageDetails(imageName: string): boolean | undefined {
@@ -33,10 +35,25 @@ export class ImageDetailsStore extends StoreBase {
         return undefined;
     }
 
+    public getImageDetails(imageName: string): IImageDetails | undefined {
+        if (this._imageDetails && this._imageDetails.hasOwnProperty(imageName)) {
+            return this._imageDetails[imageName];
+        }
+
+        return undefined;
+    }
+
     private _setHasImageDetailsData = (payload: { [key: string]: boolean } | undefined): void => {
         if (payload) {
             this._hasImageDetails = payload;
             this.emit(ImageDetailsEvents.HasImageDetailsEvent, this);
+        }
+    }
+
+    private _setImageDetailsData = (payload: IImageDetails): void => {
+        if (payload && payload.imageName) {
+            this._imageDetails[payload.imageName] = payload;
+            this.emit(ImageDetailsEvents.SetImageDetailsEvent, this);
         }
     }
 

--- a/src/WebUI/Pods/PodsDetails.tsx
+++ b/src/WebUI/Pods/PodsDetails.tsx
@@ -311,27 +311,13 @@ export class PodsDetails extends React.Component<IPodsDetailsProperties, IPodsDe
         return false;
     }
 
-    // ToDO:: Handle GetImageDetails via ImageStore to avoid multiple calls to API from UI
     private _showImageDetails = (imageId: string) => {
         const showImageDetails = (imageDetails: IImageDetails): void => {
             this.setState({
                 selectedImageDetails: imageDetails
             });
-        }
-
-        let imageDetails: IImageDetails | undefined = this._imageDetailsStore.getImageDetails(imageId);
-        if (imageDetails) {
-            showImageDetails(imageDetails);
-        }
-        else {
-            const imageService = KubeFactory.getImageService();
-            imageService && imageService.getImageDetails(imageId).then(imageDetails => {
-                if (imageDetails) {
-                    ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).setImageDetails(imageDetails);
-                    showImageDetails(imageDetails);
-                }
-            });
-        }
+        };
+        ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).getImageDetails(imageId, showImageDetails);
     }
 
     private _hideImageDetails = () => {

--- a/src/WebUI/Pods/PodsDetails.tsx
+++ b/src/WebUI/Pods/PodsDetails.tsx
@@ -313,12 +313,25 @@ export class PodsDetails extends React.Component<IPodsDetailsProperties, IPodsDe
 
     // ToDO:: Handle GetImageDetails via ImageStore to avoid multiple calls to API from UI
     private _showImageDetails = (imageId: string) => {
-        const imageService = KubeFactory.getImageService();
-        imageService && imageService.getImageDetails(imageId).then(imageDetails => {
+        const showImageDetails = (imageDetails: IImageDetails): void => {
             this.setState({
                 selectedImageDetails: imageDetails
             });
-        });
+        }
+
+        let imageDetails: IImageDetails | undefined = this._imageDetailsStore.getImageDetails(imageId);
+        if (imageDetails) {
+            showImageDetails(imageDetails);
+        }
+        else {
+            const imageService = KubeFactory.getImageService();
+            imageService && imageService.getImageDetails(imageId).then(imageDetails => {
+                if (imageDetails) {
+                    ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).setImageDetails(imageDetails);
+                    showImageDetails(imageDetails);
+                }
+            });
+        }
     }
 
     private _hideImageDetails = () => {

--- a/src/WebUI/Pods/PodsRightPanel.tsx
+++ b/src/WebUI/Pods/PodsRightPanel.tsx
@@ -20,6 +20,8 @@ import { PodsEvents, PodsRightPanelTabsKeys } from "../Constants";
 import { ActionsCreatorManager } from "../FluxCommon/ActionsCreatorManager";
 import { StoreManager } from "../FluxCommon/StoreManager";
 import { ImageDetails } from "../ImageDetails/ImageDetails";
+import { ImageDetailsActionsCreator } from "../ImageDetails/ImageDetailsActionsCreator";
+import { ImageDetailsStore } from "../ImageDetails/ImageDetailsStore";
 import { KubeFactory } from "../KubeFactory";
 import { Utils } from "../Utils";
 import { PodLog } from "./PodLog";
@@ -85,12 +87,25 @@ export class PodsRightPanel extends React.Component<IPodRightPanelProps, IPodsRi
             selectedTab: selectedPivot,
             selectedImageDetails: undefined,
             showImageDetails: (imageId: string) => {
-                const imageService = KubeFactory.getImageService();
-                imageService && imageService.getImageDetails(imageId).then(imageDetails => {
+                const showImageDetails = (imageDetails: IImageDetails): void => {
                     this.setState({
                         selectedImageDetails: imageDetails
                     });
-                });
+                }
+
+                let imageDetails: IImageDetails | undefined = StoreManager.GetStore<ImageDetailsStore>(ImageDetailsStore).getImageDetails(imageId);
+                if (imageDetails) {
+                    showImageDetails(imageDetails);
+                }
+                else {
+                    const imageService = KubeFactory.getImageService();
+                    imageService && imageService.getImageDetails(imageId).then(imageDetails => {
+                        if (imageDetails) {
+                            ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).setImageDetails(imageDetails);
+                            showImageDetails(imageDetails);
+                        }
+                    });
+                }
             }
         };
     }

--- a/src/WebUI/Pods/PodsRightPanel.tsx
+++ b/src/WebUI/Pods/PodsRightPanel.tsx
@@ -91,21 +91,8 @@ export class PodsRightPanel extends React.Component<IPodRightPanelProps, IPodsRi
                     this.setState({
                         selectedImageDetails: imageDetails
                     });
-                }
-
-                let imageDetails: IImageDetails | undefined = StoreManager.GetStore<ImageDetailsStore>(ImageDetailsStore).getImageDetails(imageId);
-                if (imageDetails) {
-                    showImageDetails(imageDetails);
-                }
-                else {
-                    const imageService = KubeFactory.getImageService();
-                    imageService && imageService.getImageDetails(imageId).then(imageDetails => {
-                        if (imageDetails) {
-                            ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).setImageDetails(imageDetails);
-                            showImageDetails(imageDetails);
-                        }
-                    });
-                }
+                };
+                ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).getImageDetails(imageId, showImageDetails);
             }
         };
     }

--- a/src/WebUI/Workloads/DeploymentsTable.tsx
+++ b/src/WebUI/Workloads/DeploymentsTable.tsx
@@ -13,6 +13,7 @@ import { Link } from "azure-devops-ui/Link";
 import { ITableColumn, ITableRow, Table } from "azure-devops-ui/Table";
 import { Tooltip } from "azure-devops-ui/TooltipEx";
 import { ArrayItemProvider } from "azure-devops-ui/Utilities/Provider";
+import { css } from "azure-devops-ui/Util";
 import * as React from "react";
 import * as Resources from "../../Resources";
 import { defaultColumnRenderer, onPodsColumnClicked, renderPodsStatusTableCell, renderTableCell } from "../Common/KubeCardWithTable";
@@ -126,7 +127,7 @@ export class DeploymentsTable extends React.Component<IDeploymentsTablePropertie
                             onActivate={(event: React.SyntheticEvent<HTMLElement>, tableRow: ITableRow<any>) => {
                                 const eventTarget = event && event.target as HTMLElement;
                                 // make sure all links have this classname
-                                if (eventTarget && !eventTarget.classList.contains(this._podsLinkClassName)) {
+                                if (eventTarget && !eventTarget.classList.contains(this._podsLinkClassName) && !eventTarget.classList.contains(this._imageLinkClassName)) {
                                     this._openDeploymentItem(event, tableRow, items[tableRow.index]);
                                 }
                             }}
@@ -278,7 +279,7 @@ export class DeploymentsTable extends React.Component<IDeploymentsTablePropertie
         const itemToRender = hasImageDetails ?
             <Tooltip overflowOnly>
                 <Link
-                    className="body-m text-ellipsis bolt-table-link"
+                    className={css("body-m text-ellipsis bolt-table-link", this._imageLinkClassName)}
                     rel={"noopener noreferrer"}
                     excludeTabStop
                     onClick={(e) => {
@@ -366,6 +367,7 @@ export class DeploymentsTable extends React.Component<IDeploymentsTablePropertie
     }
 
     private _podsLinkClassName = "d-pods-link";
+    private _imageLinkClassName = "d-image-link";
     private _store: WorkloadsStore;
     private _workloadsActionCreator: WorkloadsActionsCreator;
     private _selectionActionCreator: SelectionActionsCreator;

--- a/src/WebUI/Workloads/DeploymentsTable.tsx
+++ b/src/WebUI/Workloads/DeploymentsTable.tsx
@@ -30,6 +30,8 @@ import { Utils } from "../Utils";
 import "./DeploymentsTable.scss";
 import { WorkloadsActionsCreator } from "./WorkloadsActionsCreator";
 import { WorkloadsStore } from "./WorkloadsStore";
+import { ImageDetailsActionsCreator } from "../ImageDetails/ImageDetailsActionsCreator";
+import { IImageDetails } from "../../Contracts/Types";
 
 export interface IDeploymentsTableProperties extends IVssComponentProperties {
     nameFilter?: string;
@@ -338,18 +340,29 @@ export class DeploymentsTable extends React.Component<IDeploymentsTablePropertie
     }
 
     private _onImageClick = (imageId: string): void => {
-        const imageService = KubeFactory.getImageService();
-        imageService && imageService.getImageDetails(imageId).then(imageDetails => {
-            if (imageDetails) {
-                const payload: ISelectionPayload = {
-                    item: imageDetails,
-                    itemUID: "",
-                    showSelectedItem: true,
-                    selectedItemType: SelectedItemKeys.ImageDetailsKey
-                };
-                this._selectionActionCreator.selectItem(payload);
-            }
-        });
+        const showImageDetails = (imageDetails: IImageDetails): void => {
+            const payload: ISelectionPayload = {
+                item: imageDetails,
+                itemUID: "",
+                showSelectedItem: true,
+                selectedItemType: SelectedItemKeys.ImageDetailsKey
+            };
+            this._selectionActionCreator.selectItem(payload);
+        }
+
+        let imageDetails: IImageDetails | undefined = this._imageDetailsStore.getImageDetails(imageId);
+        if (imageDetails) {
+            showImageDetails(imageDetails);
+        }
+        else {
+            const imageService = KubeFactory.getImageService();
+            imageService && imageService.getImageDetails(imageId).then(imageDetails => {
+                if (imageDetails) {
+                    ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).setImageDetails(imageDetails);
+                    showImageDetails(imageDetails);
+                }
+            });
+        }
     }
 
     private _podsLinkClassName = "d-pods-link";

--- a/src/WebUI/Workloads/DeploymentsTable.tsx
+++ b/src/WebUI/Workloads/DeploymentsTable.tsx
@@ -349,21 +349,8 @@ export class DeploymentsTable extends React.Component<IDeploymentsTablePropertie
                 selectedItemType: SelectedItemKeys.ImageDetailsKey
             };
             this._selectionActionCreator.selectItem(payload);
-        }
-
-        let imageDetails: IImageDetails | undefined = this._imageDetailsStore.getImageDetails(imageId);
-        if (imageDetails) {
-            showImageDetails(imageDetails);
-        }
-        else {
-            const imageService = KubeFactory.getImageService();
-            imageService && imageService.getImageDetails(imageId).then(imageDetails => {
-                if (imageDetails) {
-                    ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).setImageDetails(imageDetails);
-                    showImageDetails(imageDetails);
-                }
-            });
-        }
+        };
+        ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).getImageDetails(imageId, showImageDetails);
     }
 
     private _podsLinkClassName = "d-pods-link";

--- a/src/WebUI/Workloads/OtherWorkloadsTable.tsx
+++ b/src/WebUI/Workloads/OtherWorkloadsTable.tsx
@@ -31,6 +31,7 @@ import { ISetWorkloadTypeItem, IVssComponentProperties } from "../Types";
 import { Utils } from "../Utils";
 import { WorkloadsActionsCreator } from "./WorkloadsActionsCreator";
 import { WorkloadsStore } from "./WorkloadsStore";
+import { IImageDetails } from "../../Contracts/Types";
 
 const setNameKey = "otherwrkld-name-key";
 const imageKey = "otherwrkld-image-key";
@@ -391,18 +392,29 @@ export class OtherWorkloads extends React.Component<IOtherWorkloadsProperties, I
     }
 
     private _onImageClick = (imageId: string, itemUid: string = ""): void => {
-        const imageService = KubeFactory.getImageService();
-        imageService && imageService.getImageDetails(imageId).then(imageDetails => {
-            if (imageDetails) {
-                const payload: ISelectionPayload = {
+        const showImageDetails = (imageDetails: IImageDetails): void => {
+            const payload: ISelectionPayload = {
                     item: imageDetails,
                     itemUID: itemUid,
                     showSelectedItem: true,
                     selectedItemType: SelectedItemKeys.ImageDetailsKey
                 };
                 this._selectionActionCreator.selectItem(payload);
-            }
-        });
+        }
+
+        let imageDetails: IImageDetails | undefined = this._imageDetailsStore.getImageDetails(imageId);
+        if (imageDetails) {
+            showImageDetails(imageDetails);
+        }
+        else {
+            const imageService = KubeFactory.getImageService();
+            imageService && imageService.getImageDetails(imageId).then(imageDetails => {
+                if (imageDetails) {
+                    ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).setImageDetails(imageDetails);
+                    showImageDetails(imageDetails);
+                }
+            });
+        }
     }
 
     private _podsLinkClassName = "owl-pods-link";

--- a/src/WebUI/Workloads/OtherWorkloadsTable.tsx
+++ b/src/WebUI/Workloads/OtherWorkloadsTable.tsx
@@ -401,21 +401,8 @@ export class OtherWorkloads extends React.Component<IOtherWorkloadsProperties, I
                     selectedItemType: SelectedItemKeys.ImageDetailsKey
                 };
                 this._selectionActionCreator.selectItem(payload);
-        }
-
-        let imageDetails: IImageDetails | undefined = this._imageDetailsStore.getImageDetails(imageId);
-        if (imageDetails) {
-            showImageDetails(imageDetails);
-        }
-        else {
-            const imageService = KubeFactory.getImageService();
-            imageService && imageService.getImageDetails(imageId).then(imageDetails => {
-                if (imageDetails) {
-                    ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).setImageDetails(imageDetails);
-                    showImageDetails(imageDetails);
-                }
-            });
-        }
+        };
+        ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).getImageDetails(imageId, showImageDetails);
     }
 
     private _podsLinkClassName = "owl-pods-link";

--- a/src/WebUI/Workloads/OtherWorkloadsTable.tsx
+++ b/src/WebUI/Workloads/OtherWorkloadsTable.tsx
@@ -14,6 +14,7 @@ import { Statuses } from "azure-devops-ui/Status";
 import { ITableColumn, ITableRow, Table, TwoLineTableCell } from "azure-devops-ui/Table";
 import { Tooltip } from "azure-devops-ui/TooltipEx";
 import { ArrayItemProvider } from "azure-devops-ui/Utilities/Provider";
+import { css } from "azure-devops-ui/Util";
 import * as React from "react";
 import { KubeResourceType } from "../../Contracts/KubeServiceBase";
 import * as Resources from "../../Resources";
@@ -103,7 +104,7 @@ export class OtherWorkloads extends React.Component<IOtherWorkloadsProperties, I
                             onActivate={(event: React.SyntheticEvent<HTMLElement>, tableRow: ITableRow<any>) => {
                                 const eventTarget = event && event.target as HTMLElement;
                                 // make sure all links have this classname
-                                if (eventTarget && !eventTarget.classList.contains(this._podsLinkClassName)) {
+                                if (eventTarget && !eventTarget.classList.contains(this._podsLinkClassName) && !eventTarget.classList.contains(this._imageLinkClassName)) {
                                     this._showWorkloadDetails(event, tableRow, filteredSet[tableRow.index]);
                                 }
                             }}
@@ -243,7 +244,7 @@ export class OtherWorkloads extends React.Component<IOtherWorkloadsProperties, I
         const itemToRender = hasImageDetails ?
             <Tooltip overflowOnly={true}>
                 <Link
-                    className="body-m text-ellipsis bolt-table-link"
+                    className={css("body-m text-ellipsis bolt-table-link", this._imageLinkClassName)}
                     excludeTabStop={true}
                     onClick={(e) => {
                         e.preventDefault();
@@ -418,6 +419,7 @@ export class OtherWorkloads extends React.Component<IOtherWorkloadsProperties, I
     }
 
     private _podsLinkClassName = "owl-pods-link";
+    private _imageLinkClassName = "owl-image-link";
     private _store: WorkloadsStore;
     private _actionCreator: WorkloadsActionsCreator;
     private _selectionActionCreator: SelectionActionsCreator;

--- a/src/WebUI/Workloads/WorkloadDetails.tsx
+++ b/src/WebUI/Workloads/WorkloadDetails.tsx
@@ -214,13 +214,26 @@ export class WorkloadDetails extends React.Component<IWorkloadDetailsProperties,
     }
 
     private _showImageDetails = (imageId: string) => {
-        const imageService = KubeFactory.getImageService();
-        imageService && imageService.getImageDetails(imageId).then(imageDetails => {
+        const showImageDetails = (imageDetails: IImageDetails): void => {
             this.setState({
                 showImageDetails: true,
                 selectedImageDetails: imageDetails
             });
-        });
+        }
+
+        let imageDetails: IImageDetails | undefined = this._imageDetailsStore.getImageDetails(imageId);
+        if (imageDetails) {
+            showImageDetails(imageDetails);
+        }
+        else {
+            const imageService = KubeFactory.getImageService();
+            imageService && imageService.getImageDetails(imageId).then(imageDetails => {
+                if (imageDetails) {
+                    ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).setImageDetails(imageDetails);
+                    showImageDetails(imageDetails);
+                }
+            });
+        }
     }
 
     private _hideImageDetails = () => {

--- a/src/WebUI/Workloads/WorkloadDetails.tsx
+++ b/src/WebUI/Workloads/WorkloadDetails.tsx
@@ -219,21 +219,8 @@ export class WorkloadDetails extends React.Component<IWorkloadDetailsProperties,
                 showImageDetails: true,
                 selectedImageDetails: imageDetails
             });
-        }
-
-        let imageDetails: IImageDetails | undefined = this._imageDetailsStore.getImageDetails(imageId);
-        if (imageDetails) {
-            showImageDetails(imageDetails);
-        }
-        else {
-            const imageService = KubeFactory.getImageService();
-            imageService && imageService.getImageDetails(imageId).then(imageDetails => {
-                if (imageDetails) {
-                    ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).setImageDetails(imageDetails);
-                    showImageDetails(imageDetails);
-                }
-            });
-        }
+        };
+        ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).getImageDetails(imageId, showImageDetails);
     }
 
     private _hideImageDetails = () => {

--- a/tests/WebUI/ActionsCreatorTests/ImageDetailsActionsCreator.test.ts
+++ b/tests/WebUI/ActionsCreatorTests/ImageDetailsActionsCreator.test.ts
@@ -8,49 +8,53 @@ import { MockImageService } from "../MockImageService";
 
 describe("ImageDetailsActionsCreator getImageDetails Tests", () => {
     const mockImageDetails: IImageDetails = {
-        imageName: "test-image",
-        imageUri: "test-image-uri",
-        hash: "test-image-hash",
-        baseImageName: "test-image-baseImageName",
-        imageType: "test-image-imageType",
-        mediaType: "test-image-mediaType",
+        imageName: "https://k8s.gcr.io/coredns@sha2563e2be1cec87aca0b74b7668bbe8c02964a95a402e45ceb51b2252629d608d03a",
+        imageUri: "https://k8s.gcr.io/coredns@sha2563e2be1cec87aca0b74b7668bbe8c02964a95a402e45ceb51b2252629d608d03a",
+        hash: "294f0bb6fe38fe0ab9b7ac8c6db39c2054ba038a6fe53a7cafbc20829d54a424",
+        baseImageName: "k8s.gcr.io/coredns23",
+        imageType: "",
+        mediaType: "",
         tags: ["test-image-tag"],
         layerInfo: [{ "directive": "ADD", "arguments": "mock argument", "createdOn": new Date("2019-06-25T05:50:11+05:30"), "size": "88.9MB" }],
         runId: 1,
-        pipelineVersion: "test-image-pipelineVersion",
+        pipelineVersion: "20",
         pipelineName: "test-image-pipelineName",
         pipelineId: "111",
         jobName: "test-image-jobName",
         imageSize: "1000MB",
     };
 
-    it("If imageDetails are not defined in store then call image service", () => {
-        // Mock return value for image service getImageDetails
-        const mockImageService = new MockImageService();
-        KubeFactory.getImageService = jest.fn().mockReturnValue(mockImageService);
-        mockImageService.getImageDetails = jest.fn().mockReturnValue(new Promise(() => mockImageDetails));
+    let mockImageService = new MockImageService();
+    KubeFactory.getImageService = jest.fn().mockReturnValue(mockImageService);
 
-        const mockShowImageDetailsAction = jest.fn().mockImplementation((imageDetails: IImageDetails): void => { });
+    const mockShowImageDetailsAction = jest.fn().mockImplementation((imageDetails: IImageDetails): void => { });
+
+    let imageDetailsStore = StoreManager.GetStore<ImageDetailsStore>(ImageDetailsStore);
+
+    beforeEach(() => {
+        // Mock return value for image service getImageDetails
+        mockImageService.getImageDetails = jest.fn().mockReturnValue(new Promise(() => mockImageDetails));
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("If imageDetails are not defined in store then call image service", () => {
         // mock imageDetailsStore.getImageDetails
-        const imageDetailsStore = StoreManager.GetStore<ImageDetailsStore>(ImageDetailsStore);
         imageDetailsStore.getImageDetails = jest.fn().mockReturnValueOnce(undefined);
 
         ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).getImageDetails("test-image", mockShowImageDetailsAction);
         expect(mockImageService.getImageDetails).toHaveBeenCalledWith("test-image");
+        expect(mockShowImageDetailsAction).not.toBeCalled(); // Not to be called as image details mock value is undefined here
     });
 
     it("If image details are present in store then do not call image service", () => {
-        // Mock return value for image service getImageDetails
-        const mockImageService = new MockImageService();
-        KubeFactory.getImageService = jest.fn().mockReturnValue(mockImageService);
-        mockImageService.getImageDetails = jest.fn().mockReturnValue(new Promise(() => mockImageDetails));
-
-        const mockShowImageDetailsAction = jest.fn().mockImplementation((imageDetails: IImageDetails): void => { });
         // mock imageDetailsStore.getImageDetails
-        const imageDetailsStore = StoreManager.GetStore<ImageDetailsStore>(ImageDetailsStore);
         imageDetailsStore.getImageDetails = jest.fn().mockReturnValueOnce(mockImageDetails);
-        
+
         ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).getImageDetails("test-image", mockShowImageDetailsAction);
         expect(mockImageService.getImageDetails).not.toBeCalled();
+        expect(mockShowImageDetailsAction).toBeCalledWith(mockImageDetails);
     });
 });

--- a/tests/WebUI/ActionsCreatorTests/ImageDetailsActionsCreator.test.ts
+++ b/tests/WebUI/ActionsCreatorTests/ImageDetailsActionsCreator.test.ts
@@ -1,0 +1,56 @@
+import { ImageDetailsActionsCreator } from "../../../src/WebUI/ImageDetails/ImageDetailsActionsCreator";
+import { ImageDetailsStore } from "../../../src/WebUI/ImageDetails/ImageDetailsStore";
+import { StoreManager } from "../../../src/WebUI/FluxCommon/StoreManager";
+import { ActionsCreatorManager } from "../../../src/WebUI/FluxCommon/ActionsCreatorManager";
+import { IImageDetails } from "../../../src/Contracts/Types";
+import { KubeFactory } from "../../../src/WebUI/KubeFactory";
+import { MockImageService } from "../MockImageService";
+
+describe("ImageDetailsActionsCreator getImageDetails Tests", () => {
+    const mockImageDetails: IImageDetails = {
+        imageName: "test-image",
+        imageUri: "test-image-uri",
+        hash: "test-image-hash",
+        baseImageName: "test-image-baseImageName",
+        imageType: "test-image-imageType",
+        mediaType: "test-image-mediaType",
+        tags: ["test-image-tag"],
+        layerInfo: [{ "directive": "ADD", "arguments": "mock argument", "createdOn": new Date("2019-06-25T05:50:11+05:30"), "size": "88.9MB" }],
+        runId: 1,
+        pipelineVersion: "test-image-pipelineVersion",
+        pipelineName: "test-image-pipelineName",
+        pipelineId: "111",
+        jobName: "test-image-jobName",
+        imageSize: "1000MB",
+    };
+
+    it("If imageDetails are not defined in store then call image service", () => {
+        // Mock return value for image service getImageDetails
+        const mockImageService = new MockImageService();
+        KubeFactory.getImageService = jest.fn().mockReturnValue(mockImageService);
+        mockImageService.getImageDetails = jest.fn().mockReturnValue(new Promise(() => mockImageDetails));
+
+        const mockShowImageDetailsAction = jest.fn().mockImplementation((imageDetails: IImageDetails): void => { });
+        // mock imageDetailsStore.getImageDetails
+        const imageDetailsStore = StoreManager.GetStore<ImageDetailsStore>(ImageDetailsStore);
+        imageDetailsStore.getImageDetails = jest.fn().mockReturnValueOnce(undefined);
+
+        ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).getImageDetails("test-image", mockShowImageDetailsAction);
+        expect(mockImageService.getImageDetails).toHaveBeenCalledWith("test-image");
+    });
+
+    it("If image details are present in store then do not call image service", () => {
+        // Mock return value for image service getImageDetails
+        const mockImageService = new MockImageService();
+        KubeFactory.getImageService = jest.fn().mockReturnValue(mockImageService);
+        mockImageService.getImageDetails = jest.fn().mockReturnValue(new Promise(() => mockImageDetails));
+
+        const mockShowImageDetailsAction = jest.fn().mockImplementation((imageDetails: IImageDetails): void => { });
+        // mock imageDetailsStore.getImageDetails
+        const imageDetailsStore = StoreManager.GetStore<ImageDetailsStore>(ImageDetailsStore);
+        imageDetailsStore.getImageDetails = jest.fn().mockReturnValueOnce(mockImageDetails);
+        
+        ActionsCreatorManager.GetActionCreator<ImageDetailsActionsCreator>(ImageDetailsActionsCreator).getImageDetails("test-image", mockShowImageDetailsAction);
+        expect(mockImageService.getImageDetails).not.toBeCalled();
+    });
+});

--- a/tests/WebUI/MockImageService.ts
+++ b/tests/WebUI/MockImageService.ts
@@ -1,0 +1,14 @@
+import { localeFormat } from "azure-devops-ui/Core/Util/String";
+import { KubeResourceType, KubeServiceBase } from "../../src/Contracts/KubeServiceBase";
+import { IImageService } from "../../src/Contracts/Contracts";
+import { IImageDetails } from "../../src/Contracts/Types";
+
+export class MockImageService implements IImageService {
+    public hasImageDetails(listImages: Array<string>): Promise<any> {
+        return Promise.resolve({});
+    }
+
+    public getImageDetails(imageName: string): Promise<IImageDetails | undefined> {
+        return Promise.resolve({} as IImageDetails);
+    }
+}


### PR DESCRIPTION
1.Check if image details data is already present in the store before making a call to the image service.
If not, then we make a call to service and update the store before navigating.
Associated bug - [Bug 1546523](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1546523/): Do not read images data if we have the data already
2. For deployments & OWL tables, check the class name for target element to avoid row click when image link is clicked. Fix for [Bug 1521086](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1521086/): Unable to use keyboard to open links in tables