### PR TITLE
Fetch services when workloads are zero

### DIFF
--- a/src/WebUI/Common/KubeSummary.tsx
+++ b/src/WebUI/Common/KubeSummary.tsx
@@ -232,6 +232,15 @@ export class KubeSummary extends React.Component<IKubeSummaryProps, IKubernetesC
         }, 100);
     }
 
+    public componentDidUpdate(prevProps: IKubeSummaryProps, prevState: IKubernetesContainerState) {
+        const workloadSize = this._workloadsStore.getWorkloadSize();
+        // When selected pivot is workloads but workloads do not exist, then fetch services.
+        if (this.state.resourceSize <= 0 && workloadSize <= 0 && this.state.selectedPivotKey === workloadsPivotItemKey) {
+            const kubeService = KubeFactory.getKubeService();
+            ActionsCreatorManager.GetActionCreator<ServicesActionsCreator>(ServicesActionsCreator).getServices(kubeService);
+        }
+    }
+
     public componentWillUnmount(): void {
         this._historyUnlisten();
         this._workloadsStore.removeListener(WorkloadsEvents.DeploymentsFetchedEvent, this._setNamespaceOnDeploymentsFetched);

--- a/src/WebUI/Common/KubeSummary.tsx
+++ b/src/WebUI/Common/KubeSummary.tsx
@@ -70,6 +70,7 @@ interface IKubernetesContainerState {
     workloadsFilter: Filter;
     svcFilter: Filter;
     resourceErrorType?: ResourceErrorType;
+    zeroDeploymentsFound?: boolean;
 }
 
 export interface IKubeSummaryProps extends IVssComponentProperties {
@@ -182,7 +183,8 @@ export class KubeSummary extends React.Component<IKubeSummaryProps, IKubernetesC
             resourceSize: 0,
             svcFilter: servicesFilter,
             workloadsFilter: workloadsFilter,
-            resourceErrorType: this._getResourceErrorType()
+            resourceErrorType: this._getResourceErrorType(),
+            zeroDeploymentsFound: false
         };
 
         this._servicesStore = StoreManager.GetStore<ServicesStore>(ServicesStore);
@@ -196,6 +198,7 @@ export class KubeSummary extends React.Component<IKubeSummaryProps, IKubernetesC
 
         this._workloadsStore.addListener(WorkloadsEvents.DeploymentsFetchedEvent, this._setNamespaceOnDeploymentsFetched);
         this._workloadsStore.addListener(WorkloadsEvents.WorkloadsFoundEvent, this._onDataFound);
+        this._workloadsStore.addListener(WorkloadsEvents.ZeroDeploymentsFoundEvent, this._onZeroDeploymentsFound);
         this._servicesStore.addListener(ServicesEvents.ServicesFoundEvent, this._onDataFound);
         this._selectionStore.addChangedListener(this._onSelectionStoreChanged);
 
@@ -233,9 +236,8 @@ export class KubeSummary extends React.Component<IKubeSummaryProps, IKubernetesC
     }
 
     public componentDidUpdate(prevProps: IKubeSummaryProps, prevState: IKubernetesContainerState) {
-        const workloadSize = this._workloadsStore.getWorkloadSize();
-        // When selected pivot is workloads but workloads do not exist, then fetch services.
-        if (this.state.resourceSize <= 0 && workloadSize <= 0 && this.state.selectedPivotKey === workloadsPivotItemKey) {
+        // When selected pivot is workloads but deployments do not exist, then fetch services.
+        if (this.state.resourceSize <= 0 && this.state.zeroDeploymentsFound && this.state.selectedPivotKey === workloadsPivotItemKey) {
             const kubeService = KubeFactory.getKubeService();
             ActionsCreatorManager.GetActionCreator<ServicesActionsCreator>(ServicesActionsCreator).getServices(kubeService);
         }
@@ -247,6 +249,7 @@ export class KubeSummary extends React.Component<IKubeSummaryProps, IKubernetesC
         this._workloadsStore.removeListener(WorkloadsEvents.WorkloadsFoundEvent, this._onDataFound);
         this._servicesStore.removeListener(ServicesEvents.ServicesFoundEvent, this._onDataFound);
         this._selectionStore.removeChangedListener(this._onSelectionStoreChanged);
+        this._workloadsStore.removeListener(WorkloadsEvents.ZeroDeploymentsFoundEvent, this._onZeroDeploymentsFound);
     }
 
     private _getResourceErrorType(): ResourceErrorType {
@@ -298,6 +301,10 @@ export class KubeSummary extends React.Component<IKubeSummaryProps, IKubernetesC
             const workloadStoreState = this._workloadsStore.getState();
             this.setState({ namespace: workloadStoreState.deploymentNamespace });
         }
+    }
+
+    private _onZeroDeploymentsFound = (): void => {
+        this.setState({ zeroDeploymentsFound: true });
     }
 
     private _onWorkloadsFilterApplied = (currentState: IFilterState) => {
@@ -453,18 +460,18 @@ export class KubeSummary extends React.Component<IKubeSummaryProps, IKubernetesC
         // must be short syntax or React.Fragment, do not use div here to include heading and content.
         return (
             <>
-                <TabBar
-                    selectedTabId={this.state.selectedPivotKey || workloadsPivotItemKey}
-                    onSelectedTabChanged={(key: string) => { this._selectTab(key); }}
-                    renderAdditionalContent={() => { return this._getFilterHeaderBar(); }}
-                    disableSticky={false}
-                >
-                    <Tab name={Resources.PivotWorkloadsText} id={workloadsPivotItemKey} />
-                    <Tab name={Resources.PivotServiceText} id={servicesPivotItemKey} />
-                </TabBar>
-                <div className="page-content page-content-top k8s-pivot-content">
-                    {tabContent}
-                </div>
+            <TabBar
+                selectedTabId={this.state.selectedPivotKey || workloadsPivotItemKey}
+                onSelectedTabChanged={(key: string) => { this._selectTab(key); }}
+                renderAdditionalContent={() => { return this._getFilterHeaderBar(); }}
+                disableSticky={false}
+            >
+                <Tab name={Resources.PivotWorkloadsText} id={workloadsPivotItemKey} />
+                <Tab name={Resources.PivotServiceText} id={servicesPivotItemKey} />
+            </TabBar>
+            <div className="page-content page-content-top k8s-pivot-content">
+                {tabContent}
+            </div>
             </>
         );
     }
@@ -675,12 +682,12 @@ export class KubeSummary extends React.Component<IKubeSummaryProps, IKubernetesC
     private _getFilterHeaderBar(): JSX.Element {
         return (
             <>
-                <ConditionalChildren renderChildren={!this.state.selectedPivotKey || this.state.selectedPivotKey === workloadsPivotItemKey}>
-                    <HeaderCommandBarWithFilter filter={this.state.workloadsFilter} filterToggled={workloadsFilterToggled} items={[]} />
-                </ConditionalChildren>
-                <ConditionalChildren renderChildren={this.state.selectedPivotKey === servicesPivotItemKey}>
-                    <HeaderCommandBarWithFilter filter={this.state.svcFilter} filterToggled={servicesFilterToggled} items={[]} />
-                </ConditionalChildren>
+            <ConditionalChildren renderChildren={!this.state.selectedPivotKey || this.state.selectedPivotKey === workloadsPivotItemKey}>
+                <HeaderCommandBarWithFilter filter={this.state.workloadsFilter} filterToggled={workloadsFilterToggled} items={[]} />
+            </ConditionalChildren>
+            <ConditionalChildren renderChildren={this.state.selectedPivotKey === servicesPivotItemKey}>
+                <HeaderCommandBarWithFilter filter={this.state.svcFilter} filterToggled={servicesFilterToggled} items={[]} />
+            </ConditionalChildren>
             </>
         );
     }

--- a/src/WebUI/Constants.ts
+++ b/src/WebUI/Constants.ts
@@ -25,13 +25,14 @@ export namespace WorkloadsEvents {
     export const DaemonSetsFetchedEvent: string = "DAEMON_SETS_FETCHED_EVENT";
     export const StatefulSetsFetchedEvent: string = "STATEFUL_SETS_FETCHED_EVENT";
     export const WorkloadPodsFetchedEvent: string = "WORKLOAD_PODS_FETCHED_EVENT";
-    export const WorkloadsFoundEvent: string = "ZERO_WORKLOADS_FOUND_EVENT";
+    export const WorkloadsFoundEvent: string = "NON_ZERO_WORKLOADS_FOUND_EVENT";
+    export const ZeroDeploymentsFoundEvent: string = "ZERO_DEPLOYMENTS_FOUND_EVENT";
 }
 
 export namespace ServicesEvents {
     export const ServicesFetchedEvent: string = "SERVICES_FETCHED_EVENT";
     export const ServicePodsFetchedEvent: string = "SERVICE_PODS_FETCHED_EVENT";
-    export const ServicesFoundEvent: string = "ZERO_SERVICES_FOUND_EVENT";
+    export const ServicesFoundEvent: string = "NON_ZERO_SERVICES_FOUND_EVENT";
 }
 
 export namespace PodsEvents {

--- a/src/WebUI/Workloads/WorkloadsStore.ts
+++ b/src/WebUI/Workloads/WorkloadsStore.ts
@@ -74,6 +74,9 @@ export class WorkloadsStore extends StoreBase {
         if (this._state.deploymentList && this._state.deploymentList.items && this._state.deploymentList.items.length > 0) {
             this.emit(WorkloadsEvents.WorkloadsFoundEvent, this);
         }
+        else {
+            this.emit(WorkloadsEvents.ZeroDeploymentsFoundEvent, this);
+        }
     }
 
     private _setReplicaSetsList = (replicaSetList: V1ReplicaSetList): void => {


### PR DESCRIPTION
Currently if workloads are zero and selected pivot is workloads by default, we do not fetch services which results in Default Zero data view.
Post this change we will fetch services in above scenario, show zero data view only for Workloads pivot and appropriate view for Services pivot.
Associated [Bug 1546572](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1546572/): Show services when workloads [deployments/replicasets] are zero