### PR TITLE
fixing accessibility issue of copy button

### DIFF
--- a/src/Resources.ts
+++ b/src/Resources.ts
@@ -91,6 +91,7 @@ export const TagsText = "Tags";
 export const LoadingPodsSpinnerLabel = "Loading associated pods...";
 export const LoadingServicesSpinnerLabel = "Loading services...";
 export const CopyExternalIp = "Copy External IP to clipboard";
+export const CopiedExternalIp = "Copied!";
 export const ImageDetailsUnavailableText = "Image details available only for images built in Azure Pipelines";
 export const PodDetailsSubheader = "Pods in {0}";
 export const ClusterLinkHelpText = "Navigation to cluster details is only available for the Azure provider";

--- a/src/WebUI/Services/ServiceDetails.tsx
+++ b/src/WebUI/Services/ServiceDetails.tsx
@@ -43,6 +43,7 @@ export interface IServiceDetailsState {
     service: IServiceItem | undefined;
     pods: Array<V1Pod>;
     arePodsLoading?: boolean;
+    copyTooltipText?: string;
 }
 
 const LoadBalancerText: string = "LoadBalancer";
@@ -53,7 +54,8 @@ export class ServiceDetails extends React.Component<IServiceDetailsProperties, I
         this.state = {
             service: props.service,
             pods: [],
-            arePodsLoading: true
+            arePodsLoading: true,
+            copyTooltipText: Resources.CopyExternalIp
         };
 
         getTelemetryService().scenarioStart(Scenarios.ServiceDetails);
@@ -211,7 +213,7 @@ export class ServiceDetails extends React.Component<IServiceDetailsProperties, I
                 return (
                     <div className="body-m service-column-padding" key={index}>
                         {getColumnKey(key, "service-extip-column-size")}
-                        {renderExternalIpWithCopy(value)}
+                        {renderExternalIpWithCopy(value, this.state.copyTooltipText, this._setCopiedRowIndex)}
                     </div>
                 );
 
@@ -278,6 +280,12 @@ export class ServiceDetails extends React.Component<IServiceDetailsProperties, I
                 } as IPodDetailsSelectionProperties
             }
         );
+    }
+
+    private _setCopiedRowIndex = (copiedRowIndex: number): void => {
+        this.setState({
+            copyTooltipText: copiedRowIndex === 0 ? Resources.CopiedExternalIp : Resources.CopyExternalIp
+        });
     }
 
     private _isTTIMarked: boolean = false;

--- a/src/WebUI/Services/ServicesTable.tsx
+++ b/src/WebUI/Services/ServicesTable.tsx
@@ -33,15 +33,17 @@ export interface IServicesComponentProperties extends IVssComponentProperties {
 }
 
 export interface IServicesTableState {
-    hoverRowIndex: number;
+    copiedRowIndex: number;
 }
 
 export class ServicesTable extends React.Component<IServicesComponentProperties, IServicesTableState> {
     constructor(props: IServicesComponentProperties) {
         super(props, {});
+
         this.state = {
-            hoverRowIndex: -1
+            copiedRowIndex: -1
         };
+
         this._selectionActionCreator = ActionsCreatorManager.GetActionCreator<SelectionActionsCreator>(SelectionActionsCreator);
     }
 
@@ -52,7 +54,7 @@ export class ServicesTable extends React.Component<IServicesComponentProperties,
             });
 
         if (filteredSvc.length > 0) {
-            const serviceItems = getServiceItems(filteredSvc);
+            const serviceItems = getServiceItems(filteredSvc).map((item, index) => { item.externalIPTooltip = index === this.state.copiedRowIndex ? Resources.CopiedExternalIp : Resources.CopyExternalIp; return item });
             const tableProps = {
                 id: "services-list-table",
                 showHeader: true,
@@ -118,7 +120,7 @@ export class ServicesTable extends React.Component<IServicesComponentProperties,
             id: "externalIP",
             name: Resources.ExternalIPText,
             width: new ObservableValue(172),
-            renderCell: (rowIndex, columnIndex, tableColumn, service) => renderExternalIpCell(rowIndex, columnIndex, tableColumn, service, this._setHoverRowIndex, this.state.hoverRowIndex)
+            renderCell: (rowIndex, columnIndex, tableColumn, service) => renderExternalIpCell(rowIndex, columnIndex, tableColumn, service, this._setCopiedRowIndex)
         });
 
         columns.push({
@@ -147,9 +149,9 @@ export class ServicesTable extends React.Component<IServicesComponentProperties,
         return renderTableCell(rowIndex, columnIndex, tableColumn, itemToRender);
     }
 
-    private _setHoverRowIndex = (hoverRowIndex: number): void => {
+    private _setCopiedRowIndex = (copiedRowIndex: number): void => {
         this.setState({
-            hoverRowIndex: hoverRowIndex
+            copiedRowIndex: copiedRowIndex
         });
     }
 

--- a/src/WebUI/Types.d.ts
+++ b/src/WebUI/Types.d.ts
@@ -50,6 +50,7 @@ export interface IServiceItem {
     pipeline: string;
     service?: V1Service;
     kind?: string;
+    externalIPTooltip?: string;
 }
 
 export interface IDeploymentReplicaSetMap {


### PR DESCRIPTION
We are fixing the following bug:
[Bug 1554488](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1554488/): A11y_AzureDevOps_ServicesTab_Usability:Clear instructions are not mentioned to access the "Copy" button.

on selection of the row or on hover we are showing the copy button, so that left/right arrow will work in services table
![image](https://user-images.githubusercontent.com/26214977/60342348-dc4f2d80-99ce-11e9-9bdb-a7be03c4a85c.png)

on click of the copy button we do show copied
![image](https://user-images.githubusercontent.com/26214977/60342378-f25cee00-99ce-11e9-8228-002f25ed9a92.png)

Same experience for service table also:
![image](https://user-images.githubusercontent.com/26214977/60342449-16203400-99cf-11e9-8f5f-819d22171c4b.png)

