### PR TITLE
Reducing the number of renders on Workloads pivot

### DIFF
--- a/src/WebUI/Types.d.ts
+++ b/src/WebUI/Types.d.ts
@@ -11,6 +11,9 @@ interface IBaseProps<T = any> {
     componentRef?: (ref: T | null) => (void | T);
 }
 
+
+export type K8sObject = V1DaemonSet | V1StatefulSet | V1ReplicaSet | V1Pod | V1Deployment;
+
 export interface IKubernetesSummary {
     namespace?: string;
     podList?: V1PodList;

--- a/src/WebUI/Utils.ts
+++ b/src/WebUI/Utils.ts
@@ -11,6 +11,7 @@ import { IStatusProps, Statuses } from "azure-devops-ui/Status";
 import { PodPhase } from "../Contracts/Contracts";
 import * as Resources from "../Resources";
 import { SelectedItemKeys } from "./Constants";
+import { K8sObject } from "./Types";
 
 const pipelineNameAnnotationKey: string = "azure-pipelines/pipeline";
 const pipelineRunIdAnnotationKey: string = "azure-pipelines/execution";
@@ -347,5 +348,21 @@ export class Utils {
         document.addEventListener("copy", listener);
         document.execCommand("copy");
         document.removeEventListener("copy", listener);
+    }
+
+    public static isDeepEquals( baseObject: K8sObject[] , compareObject: K8sObject[] ): boolean {
+        let isDeepEquals = false;
+        if( baseObject.length === compareObject.length ) {
+           const baseObjectUids =  baseObject.map( obj => obj.metadata.uid);
+           const compareObjectUids = compareObject.map( obj => obj.metadata.uid);
+           isDeepEquals = true;
+           for(const uid  of compareObjectUids) {
+               if (baseObjectUids.indexOf(uid) < 0) {
+                  isDeepEquals = false;
+                  break;
+               }
+           }
+        }
+        return isDeepEquals;
     }
 }

--- a/src/WebUI/Workloads/DeploymentsTable.tsx
+++ b/src/WebUI/Workloads/DeploymentsTable.tsx
@@ -61,7 +61,7 @@ export class DeploymentsTable extends React.Component<IDeploymentsTablePropertie
 
 
     public render(): React.ReactNode {
-        const deployments = this.state.deploymentList;
+        const deployments = this._store.getState().deploymentList;
         const filteredDeployments: V1Deployment[] = (deployments && deployments.items || []).filter((deployment) => {
             return Utils.filterByName(deployment.metadata.name, this.props.nameFilter);
         });
@@ -78,15 +78,8 @@ export class DeploymentsTable extends React.Component<IDeploymentsTablePropertie
         this._imageDetailsStore.removeListener(ImageDetailsEvents.HasImageDetailsEvent, this._setHasImageDetails);
     }
 
-    // deployments have already been populated in store by KubeSummary parent component
     private _onReplicaSetsFetched = (): void => {
-        const storeState = this._store.getState();
-        this.setState({
-            deploymentList: storeState.deploymentList,
-            replicaSetList: storeState.replicaSetList
-        }, () => {
-            this.props.markTTICallback && this.props.markTTICallback({ "component": "DeploymentTable" });
-        });
+        this.props.markTTICallback && this.props.markTTICallback({ "component": "DeploymentTable" });
     }
 
     private _setHasImageDetails = (): void => {
@@ -95,7 +88,7 @@ export class DeploymentsTable extends React.Component<IDeploymentsTablePropertie
 
     private _getDeploymentListView(filteredDeployments: V1Deployment[]) {
         let renderList: JSX.Element[] = [];
-        DeploymentsTable._generateDeploymentReplicaSetMap(filteredDeployments, this.state.replicaSetList).forEach((entry, index) => {
+        DeploymentsTable._generateDeploymentReplicaSetMap(filteredDeployments, this._store.getState().replicaSetList).forEach((entry, index) => {
             const items = DeploymentsTable._getDeploymentReplicaSetItems(entry.deployment, entry.replicaSets);
             const key = format("workloads-d-t-{0}", index);
             const tableProps = {
@@ -332,7 +325,7 @@ export class DeploymentsTable extends React.Component<IDeploymentsTablePropertie
         // have one selection store, raise action to send selectedItem, in the store
         if (selectedItem && selectedItem.replicaSetId) {
             const selectedItemReplicaSetUId: string = selectedItem.replicaSetId.toLowerCase();
-            const replicas = this.state.replicaSetList;
+            const replicas = this._store.getState().replicaSetList;
             const filteredReplicas = (replicas && replicas.items || []).filter(r => {
                 return r.metadata.uid.toLowerCase() === selectedItemReplicaSetUId;
             });

--- a/src/WebUI/Workloads/OtherWorkloadsTable.tsx
+++ b/src/WebUI/Workloads/OtherWorkloadsTable.tsx
@@ -122,6 +122,13 @@ export class OtherWorkloads extends React.Component<IOtherWorkloadsProperties, I
         return null;
     }
 
+    public shouldComponentUpdate(): boolean {
+        //holding off multiple renders for each set fetch
+        let metaInitialized = true;
+        Object.keys(this._metadataInitialized).forEach(key => metaInitialized = metaInitialized && this._metadataInitialized[key]);
+        return metaInitialized;
+    }
+
     public componentWillUnmount(): void {
         this._imageDetailsStore.removeListener(ImageDetailsEvents.HasImageDetailsEvent, this._setHasImageDetails);
         this._store.removeListener(WorkloadsEvents.DaemonSetsFetchedEvent, this._onDaemonSetsFetched);
@@ -132,33 +139,47 @@ export class OtherWorkloads extends React.Component<IOtherWorkloadsProperties, I
 
     private _onStatefulSetsFetched = (): void => {
         const storeState = this._store.getState();
-        this.setState({
-            statefulSets: storeState.statefulSetList && storeState.statefulSetList.items || []
-        }, () => this._onMetadataFetch("statefulsets"));
+        const statefulSets = storeState.statefulSetList && storeState.statefulSetList.items || [];
+        if (statefulSets.length > 0) {
+            this.setState({
+                statefulSets: storeState.statefulSetList && storeState.statefulSetList.items || []
+            });
+        }
+        this._onMetadataFetch("statefulsets");
     }
 
     private _onDaemonSetsFetched = (): void => {
         const storeState = this._store.getState();
-        this.setState({
-            daemonSets: storeState.daemonSetList && storeState.daemonSetList.items || []
-        }, () => this._onMetadataFetch("daemon"));
+        const daemonSets = storeState.daemonSetList && storeState.daemonSetList.items || [];
+        if (daemonSets.length > 0) {
+            this.setState({
+                daemonSets: storeState.daemonSetList && storeState.daemonSetList.items || []
+            });
+        }
+        this._onMetadataFetch("daemon");
     }
 
     private _onReplicaSetsFetched = (): void => {
         const storeState = this._store.getState();
         const allReplicaSets = storeState.replicaSetList && storeState.replicaSetList.items || [];
         const standAloneReplicaSets = allReplicaSets.filter(set => set.metadata.ownerReferences.length === 0);
-        this.setState({
-            replicaSets: standAloneReplicaSets
-        }, () => this._onMetadataFetch("replicasets"))
+        if (standAloneReplicaSets.length > 0) {
+            this.setState({
+                replicaSets: standAloneReplicaSets
+            });
+        }
+        this._onMetadataFetch("replicasets");
     }
 
     private _onOrphanPodsFetched = (): void => {
         const storeState = this._store.getState();
         const orphanPods = storeState.orphanPodsList || [];
-        this.setState({
-            orphanPods: orphanPods
-        }, () => this._onMetadataFetch("orphanpods"));
+        if (orphanPods.length > 0) {
+            this.setState({
+                orphanPods: orphanPods
+            });
+        }
+        this._onMetadataFetch("orphanpods");
     }
 
     private _setHasImageDetails = (): void => {

--- a/src/WebUI/Workloads/WorkloadsPivot.tsx
+++ b/src/WebUI/Workloads/WorkloadsPivot.tsx
@@ -91,9 +91,11 @@ export class WorkloadsPivot extends React.Component<IWorkloadsPivotProps, IWorkl
         const podlist: V1PodList | undefined = this._podsStore.getState().podsList;
         if (podlist && podlist.items && podlist.items.length > 0) {
             const imageList = Utils.getImageIdsForPods(podlist.items);
-            this.setState({
-                imageList: imageList
-            });
+            if (imageList && imageList.length > 0) {
+                this.setState({
+                    imageList: imageList
+                });
+            }
         }
     }
 

--- a/src/WebUI/Workloads/WorkloadsStore.ts
+++ b/src/WebUI/Workloads/WorkloadsStore.ts
@@ -9,6 +9,7 @@ import { ActionsHubManager } from "../FluxCommon/ActionsHubManager";
 import { StoreBase } from "../FluxCommon/Store";
 import { IPodsPayload, PodsActions } from "../Pods/PodsActions";
 import { WorkloadsActions } from "./WorkloadsActions";
+import { Utils } from "../Utils";
 
 export interface IWorkloadsStoreState {
     deploymentNamespace?: string;
@@ -60,17 +61,19 @@ export class WorkloadsStore extends StoreBase {
     }
 
     private _setDeploymentsList = (deploymentsList: V1DeploymentList): void => {
-        this._state.deploymentList = deploymentsList;
-        const deploymentItems = deploymentsList ? deploymentsList.items || [] : [];
-        for (const deployment of deploymentItems) {
-            if (deployment && deployment.metadata.namespace) {
-                this._state.deploymentNamespace = deployment.metadata.namespace;
-                break;
+        const _stateItems = this._state.deploymentList ? this._state.deploymentList.items : [];
+        const _deploymentItems = deploymentsList ? deploymentsList.items : [];
+        if (!Utils.isDeepEquals(_stateItems, _deploymentItems)) {
+            this._state.deploymentList = deploymentsList;
+            const deploymentItems = deploymentsList ? deploymentsList.items || [] : [];
+            for (const deployment of deploymentItems) {
+                if (deployment && deployment.metadata.namespace) {
+                    this._state.deploymentNamespace = deployment.metadata.namespace;
+                    break;
+                }
             }
         }
-
         this.emit(WorkloadsEvents.DeploymentsFetchedEvent, this);
-
         if (this._state.deploymentList && this._state.deploymentList.items && this._state.deploymentList.items.length > 0) {
             this.emit(WorkloadsEvents.WorkloadsFoundEvent, this);
         }
@@ -80,7 +83,11 @@ export class WorkloadsStore extends StoreBase {
     }
 
     private _setReplicaSetsList = (replicaSetList: V1ReplicaSetList): void => {
-        this._state.replicaSetList = replicaSetList;
+        const _stateItems = this._state.replicaSetList ? this._state.replicaSetList.items : [];
+        const _replicaItems = replicaSetList ? replicaSetList.items : [];
+        if (!Utils.isDeepEquals(_stateItems, _replicaItems)) {
+            this._state.replicaSetList = replicaSetList;
+        }
         this.emit(WorkloadsEvents.ReplicaSetsFetchedEvent, this);
         if (this._state.replicaSetList && this._state.replicaSetList.items && this._state.replicaSetList.items.length > 0) {
             this.emit(WorkloadsEvents.WorkloadsFoundEvent, this);
@@ -88,7 +95,11 @@ export class WorkloadsStore extends StoreBase {
     }
 
     private _setDaemonSetsList = (daemonSetList: V1DaemonSetList): void => {
-        this._state.daemonSetList = daemonSetList;
+        const _stateItems = this._state.daemonSetList ? this._state.daemonSetList.items : [];
+        const _daemonSetItems = daemonSetList ? daemonSetList.items : [];
+        if (!Utils.isDeepEquals(_stateItems, _daemonSetItems)) {
+            this._state.daemonSetList = daemonSetList;
+        }
         this.emit(WorkloadsEvents.DaemonSetsFetchedEvent, this);
         if (this._state.daemonSetList && this._state.daemonSetList.items && this._state.daemonSetList.items.length > 0) {
             this.emit(WorkloadsEvents.WorkloadsFoundEvent, this);
@@ -96,7 +107,11 @@ export class WorkloadsStore extends StoreBase {
     }
 
     private _setStatefulsetsList = (statefulSetList: V1StatefulSetList): void => {
-        this._state.statefulSetList = statefulSetList;
+        const _stateItems = this._state.statefulSetList ? this._state.statefulSetList.items : [];
+        const _stateFulSetItems = statefulSetList ? statefulSetList.items : [];
+        if (!Utils.isDeepEquals(_stateItems, _stateFulSetItems)) {
+            this._state.statefulSetList = statefulSetList;
+        }
         this.emit(WorkloadsEvents.StatefulSetsFetchedEvent, this);
         if (this._state.statefulSetList && this._state.statefulSetList.items && this._state.statefulSetList.items.length > 0) {
             this.emit(WorkloadsEvents.WorkloadsFoundEvent, this);
@@ -110,10 +125,10 @@ export class WorkloadsStore extends StoreBase {
                 orphanPods.push(pod);
             }
         });
-
-        this._state.orphanPodsList = orphanPods;
+        if (!Utils.isDeepEquals(this._state.orphanPodsList || [], orphanPods)) {
+            this._state.orphanPodsList = orphanPods;
+        }
         this.emit(WorkloadsEvents.WorkloadPodsFetchedEvent, this);
-
         if (this._state.orphanPodsList && this._state.orphanPodsList.length > 0) {
             this.emit(WorkloadsEvents.WorkloadsFoundEvent, this);
         }


### PR DESCRIPTION
1. Reducing the number of renders in OtherWorkloads Component by holding off refresh until data is fetched
2. Modified Workloads UI to read from store instead of setting replicasets to State. Reducing one render
