### PR TITLE
Fixing Accessibility issue for cluster url

### DIFF
--- a/src/WebUI/Common/KubeSummary.scss
+++ b/src/WebUI/Common/KubeSummary.scss
@@ -59,7 +59,7 @@
         }
     }
 
-    .cluster-link {
-        display: block
+    .cluster-link>:last-child {
+        margin-bottom: 4px
     }
 }

--- a/src/WebUI/Common/KubeSummary.scss
+++ b/src/WebUI/Common/KubeSummary.scss
@@ -58,4 +58,8 @@
             }
         }
     }
+
+    .cluster-link {
+        display: block
+    }
 }

--- a/src/WebUI/Common/KubeSummary.scss
+++ b/src/WebUI/Common/KubeSummary.scss
@@ -59,7 +59,7 @@
         }
     }
 
-    .cluster-link>:last-child {
-        margin-bottom: 4px
+    .k8s-user-action-margin>:last-child {
+        margin-bottom: 4px;
     }
 }

--- a/src/WebUI/Common/KubeSummary.tsx
+++ b/src/WebUI/Common/KubeSummary.tsx
@@ -358,7 +358,7 @@ export class KubeSummary extends React.Component<IKubeSummaryProps, IKubernetesC
 
         // show cluster if available, and show namespace only if namespaces list is not available
         return (
-            <div className={css("flex-column rhythm-vertical-8", "cluster-link")}>
+            <div className={css("flex-column rhythm-vertical-8", this._doesHeaderNeedMargin() ? "k8s-user-action-margin" : "")}>
                 {
                     /* show clustername always if it is available */
                     this._getHeaderClusterNameComponent()
@@ -398,6 +398,13 @@ export class KubeSummary extends React.Component<IKubeSummaryProps, IKubernetesC
                 }
             </div>
         );
+    }
+
+    private _doesHeaderNeedMargin(): boolean {
+        // need margin if cluster has link or namespaces dropdown is shown
+        // otherwise focus selection is not visible properly when keyboard is used
+        const availableNamespaces = this.props.namespaces || [];
+        return !!this.props.clusterUrl || availableNamespaces.length > 0;
     }
 
     private _getHeaderClusterNameComponent(): JSX.Element | null {

--- a/src/WebUI/Common/KubeSummary.tsx
+++ b/src/WebUI/Common/KubeSummary.tsx
@@ -16,6 +16,7 @@ import { Spinner, SpinnerSize } from "azure-devops-ui/Spinner";
 import { IStatusProps } from "azure-devops-ui/Status";
 import { Surface, SurfaceBackground } from "azure-devops-ui/Surface";
 import { Tab, TabBar } from "azure-devops-ui/Tabs";
+import { css } from "azure-devops-ui/Util";
 import { DropdownSelection } from "azure-devops-ui/Utilities/DropdownSelection";
 import { Filter, FILTER_CHANGE_EVENT, IFilterState } from "azure-devops-ui/Utilities/Filter";
 import { Action, createBrowserHistory, History, Location, UnregisterCallback } from "history";
@@ -357,7 +358,7 @@ export class KubeSummary extends React.Component<IKubeSummaryProps, IKubernetesC
 
         // show cluster if available, and show namespace only if namespaces list is not available
         return (
-            <div className="flex-column rhythm-vertical-8">
+            <div className={css("flex-column rhythm-vertical-8", this.props.clusterUrl && "cluster-link")}>
                 {
                     /* show clustername always if it is available */
                     this._getHeaderClusterNameComponent()

--- a/src/WebUI/Common/KubeSummary.tsx
+++ b/src/WebUI/Common/KubeSummary.tsx
@@ -358,7 +358,7 @@ export class KubeSummary extends React.Component<IKubeSummaryProps, IKubernetesC
 
         // show cluster if available, and show namespace only if namespaces list is not available
         return (
-            <div className={css("flex-column rhythm-vertical-8", this.props.clusterUrl && "cluster-link")}>
+            <div className={css("flex-column rhythm-vertical-8", "cluster-link")}>
                 {
                     /* show clustername always if it is available */
                     this._getHeaderClusterNameComponent()
@@ -404,12 +404,14 @@ export class KubeSummary extends React.Component<IKubeSummaryProps, IKubernetesC
         // show clustername always if it is available
         if (this.props.clusterName) {
             return this.props.clusterUrl ?
-                <Link
-                    href={this.props.clusterUrl}
-                    target="_blank"
-                    rel="nofollow noopener">
-                    {localeFormat(Resources.SummaryHeaderSubTextFormat, this.props.clusterName)}
-                </Link>
+                <span>
+                    <Link
+                        href={this.props.clusterUrl}
+                        target="_blank"
+                        rel="nofollow noopener">
+                        {localeFormat(Resources.SummaryHeaderSubTextFormat, this.props.clusterName)}
+                    </Link>
+                </span>
                 : <Tooltip text={Resources.ClusterLinkHelpText}>
                     <div>{localeFormat(Resources.SummaryHeaderSubTextFormat, this.props.clusterName)}</div>
                 </Tooltip>;


### PR DESCRIPTION
Cluster URL cannot be navigated using keyboard. Fixing the display type to correct the wrapping

![accessibility_clusterlink](https://user-images.githubusercontent.com/45386516/60718647-dadbb300-9f42-11e9-9fbb-6cd407270cfa.jpg)
