### PR TITLE
delete query params if their value is blank

### DIFF
--- a/src/WebUI/Selection/SelectionActionCreator.ts
+++ b/src/WebUI/Selection/SelectionActionCreator.ts
@@ -40,13 +40,15 @@ export class SelectionActionsCreator extends ActionCreatorBase {
                 if (!!value && typeof value !== "object" && typeof value !== "function") {
                     routeValues[k] = value;
                 }
-
-                // We will send undefined or empty for values that we want deleted from the url
-                if (!value) {
-                    delete routeValues[k];
-                }
             });
         }
+
+        Object.keys(routeValues).forEach(k => {
+            // delete the properties which has empty value
+            if (!routeValues[k]) {
+                delete routeValues[k];
+            }
+        });
 
         historyService.push({
             pathname: historyService.location.pathname,

--- a/src/WebUI/Selection/SelectionActionCreator.ts
+++ b/src/WebUI/Selection/SelectionActionCreator.ts
@@ -35,18 +35,21 @@ export class SelectionActionsCreator extends ActionCreatorBase {
         // So, our design should be careful in handling those
         if (payload.properties) {
             // Add all the non-object, non-function and defined values to the url route. This will be read by the view loading itself
-            Object.keys(payload.properties).forEach(k => {
-                const value = payload.properties![k];
-                if (!!value && typeof value !== "object" && typeof value !== "function") {
-                    routeValues[k] = value;
+            Object.keys(payload.properties).forEach(pk => {
+                let pValue = payload.properties![pk];
+                if (pValue !== undefined && pValue !== null) {
+                    pValue = (typeof pValue !== "object" && typeof pValue !== "function") ? pValue : "";
+                    routeValues[pk] = pValue;
                 }
             });
         }
 
-        Object.keys(routeValues).forEach(k => {
-            // delete the properties which has empty value
-            if (!routeValues[k]) {
-                delete routeValues[k];
+        Object.keys(routeValues).forEach(rk => {
+            const paramValue = routeValues[rk];
+            // delete the properties which has no value
+            if (paramValue === undefined || paramValue === null || paramValue === "") {
+                // do not delete keys with value: 0 or false
+                delete routeValues[rk];
             }
         });
 

--- a/src/WebUI/Selection/SelectionActionCreator.ts
+++ b/src/WebUI/Selection/SelectionActionCreator.ts
@@ -36,10 +36,12 @@ export class SelectionActionsCreator extends ActionCreatorBase {
         if (payload.properties) {
             // Add all the non-object, non-function and defined values to the url route. This will be read by the view loading itself
             Object.keys(payload.properties).forEach(pk => {
-                let pValue = payload.properties![pk];
-                if (pValue !== undefined && pValue !== null) {
-                    pValue = (typeof pValue !== "object" && typeof pValue !== "function") ? pValue : "";
+                const pValue = payload.properties![pk];
+                if (pValue !== undefined && pValue !== null && typeof pValue !== "object" && typeof pValue !== "function" && pValue !== "") {
                     routeValues[pk] = pValue;
+                }
+                else {
+                    delete routeValues[pk];
                 }
             });
         }

--- a/src/WebUI/Selection/SelectionActionCreator.ts
+++ b/src/WebUI/Selection/SelectionActionCreator.ts
@@ -37,6 +37,8 @@ export class SelectionActionsCreator extends ActionCreatorBase {
             // Add all the non-object, non-function and defined values to the url route. This will be read by the view loading itself
             Object.keys(payload.properties).forEach(pk => {
                 const pValue = payload.properties![pk];
+                // do assign value of 0 or false
+                // delete the key which has no value
                 if (pValue !== undefined && pValue !== null && typeof pValue !== "object" && typeof pValue !== "function" && pValue !== "") {
                     routeValues[pk] = pValue;
                 }
@@ -49,8 +51,8 @@ export class SelectionActionsCreator extends ActionCreatorBase {
         Object.keys(routeValues).forEach(rk => {
             const paramValue = routeValues[rk];
             // delete the properties which has no value
+            // do not delete param value with 0 or false
             if (paramValue === undefined || paramValue === null || paramValue === "") {
-                // do not delete keys with value: 0 or false
                 delete routeValues[rk];
             }
         });


### PR DESCRIPTION
when we move to image details and get back to workloads pivot, some of the params has empty values, deleting those