### PR TITLE
fixing padding when image or pods is not link

### DIFF
--- a/src/Resources.ts
+++ b/src/Resources.ts
@@ -17,6 +17,7 @@ export const PodsText = "Pods";
 export const PodText = "Pod";
 export const PortText = "Port";
 export const NamespaceLabelText = "Namespace:";
+export const NamespaceWithValueText = "Namespace: {0}";
 export const PivotServiceText = "Services";
 export const PivotWorkloadsText = "Workloads";
 export const PodIP = "IP";

--- a/src/WebUI/Common/KubeCardWithTable.tsx
+++ b/src/WebUI/Common/KubeCardWithTable.tsx
@@ -247,7 +247,7 @@ export function renderPodsStatusTableCell(
                     </span>)}
         </Tooltip>;
 
-    return renderTableCell(rowIndex, columnIndex, tableColumn, itemToRender, undefined, podsCountString ? "bolt-table-cell-content-with-link" : "");
+    return renderTableCell(rowIndex, columnIndex, tableColumn, itemToRender, undefined, podsCountString && onClick ? "bolt-table-cell-content-with-link" : "");
 }
 
 export function onPodsColumnClicked(

--- a/src/WebUI/Common/KubeSummary.tsx
+++ b/src/WebUI/Common/KubeSummary.tsx
@@ -390,9 +390,8 @@ export class KubeSummary extends React.Component<IKubeSummaryProps, IKubernetesC
                 {
                     /* show namespace only if clustername is not available or namespaces list not set */
                     !this.props.clusterName && availableNamespaces.length <= 0 &&
-                    <div className="flex-row flex-center rhythm-horizontal-8">
-                        <div>{Resources.NamespaceLabelText}</div>
-                        <div>{namespaceText}</div>
+                    <div className="rhythm-horizontal-8">
+                        <span>{localeFormat(Resources.NamespaceWithValueText, namespaceText)}</span>
                     </div>
                 }
             </div>

--- a/src/WebUI/Workloads/OtherWorkloadsTable.tsx
+++ b/src/WebUI/Workloads/OtherWorkloadsTable.tsx
@@ -261,7 +261,7 @@ export class OtherWorkloads extends React.Component<IOtherWorkloadsProperties, I
             </Tooltip>
             : defaultColumnRenderer(imageText, "body-m", imageDetailsUnavailableTooltipText);
 
-        return renderTableCell(rowIndex, columnIndex, tableColumn, itemToRender, undefined, "bolt-table-cell-content-with-link");
+        return renderTableCell(rowIndex, columnIndex, tableColumn, itemToRender, undefined, hasImageDetails ? "bolt-table-cell-content-with-link" : "");
     }
 
     private _renderPodsCountCell = (rowIndex: number, columnIndex: number, tableColumn: ITableColumn<ISetWorkloadTypeItem>, workload: ISetWorkloadTypeItem): JSX.Element => {


### PR DESCRIPTION
Before fix
![image](https://user-images.githubusercontent.com/26214977/61862285-4635f680-aeeb-11e9-926c-2f6f335e1d8f.png)

After fix:
![image](https://user-images.githubusercontent.com/26214977/61862299-4b934100-aeeb-11e9-83d0-510654253eef.png)

Before fix for the podlink:
![image](https://user-images.githubusercontent.com/26214977/61863207-cc067180-aeec-11e9-8afd-cfd75b8bb099.png)

post fix:
![image](https://user-images.githubusercontent.com/26214977/61863268-ea6c6d00-aeec-11e9-846a-c4478db62a29.png)
