### PR TITLE
Removed hash from ImageDetails

### DIFF
--- a/src/Contracts/Types.d.ts
+++ b/src/Contracts/Types.d.ts
@@ -6,7 +6,6 @@
 export interface IImageDetails {
     imageName: string;
     imageUri: string;
-    hash: string;
     baseImageName: string;
     distance?: number;
     imageType: string;

--- a/src/WebUI/ImageDetails/ImageDetails.tsx
+++ b/src/WebUI/ImageDetails/ImageDetails.tsx
@@ -116,7 +116,7 @@ export class ImageDetails extends React.Component<IImageDetailsProperties, IImag
 
     private _getImageDetailsRowsData(imageDetails: IImageDetails): any[] {
         let imageDetailsRows: any[] = [];
-        const digest: string = imageDetails.hash || "";
+        const digest: string = Utils.getDigestFromImageResourceUrl(imageDetails.imageUri);
         const imageType: string = imageDetails.imageType || "";
         const mediaType: string = imageDetails.mediaType || "";
         const registryName: string = this._getRegistryName();

--- a/src/WebUI/Utils.ts
+++ b/src/WebUI/Utils.ts
@@ -252,12 +252,20 @@ export class Utils {
         return "";
     }
 
+    public static getDigestFromImageResourceUrl(imageId: string): string {
+        if (imageId) {
+            return Utils.getImageResourceUrlParameter(imageId, matchPatternForDigest);
+        }
+
+        return "";
+    }
+
     public static getImageResourceUrl(imageId: string): string {
         const sha256Text = "@sha256:";
         const separator = "://";
         let indexOfSeparator = imageId.indexOf(separator);
         let image = indexOfSeparator >= 0 ? imageId.substr(indexOfSeparator + separator.length) : imageId;
-        const digest = Utils.getImageResourceUrlParameter(imageId, matchPatternForDigest);
+        const digest = Utils.getDigestFromImageResourceUrl(imageId);
 
         // This match pattern is copied over from DockerV2 task to maintain parity between image Urls
         let match = image.match(/^(?:([^\/]+)\/)?(?:([^\/]+)\/)?([^@:\/]+)(?:[@:](.+))?$/);

--- a/tests/WebUI/ActionsCreatorTests/ImageDetailsActionsCreator.test.ts
+++ b/tests/WebUI/ActionsCreatorTests/ImageDetailsActionsCreator.test.ts
@@ -10,7 +10,6 @@ describe("ImageDetailsActionsCreator getImageDetails Tests", () => {
     const mockImageDetails: IImageDetails = {
         imageName: "https://k8s.gcr.io/coredns@sha2563e2be1cec87aca0b74b7668bbe8c02964a95a402e45ceb51b2252629d608d03a",
         imageUri: "https://k8s.gcr.io/coredns@sha2563e2be1cec87aca0b74b7668bbe8c02964a95a402e45ceb51b2252629d608d03a",
-        hash: "294f0bb6fe38fe0ab9b7ac8c6db39c2054ba038a6fe53a7cafbc20829d54a424",
         baseImageName: "k8s.gcr.io/coredns23",
         imageType: "",
         mediaType: "",


### PR DESCRIPTION
Hash details are already present in the image resource URL so extracting it directly from there.
V1 version of Grafeas does not support Resource in ImageOccurrence, it only has ResourceUrl.